### PR TITLE
Fix fetchMessageBody and fetchMessage to verify UID in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `searchMessages()` now uses UIDs internally to prevent race conditions (#1)
 
+### Fixed
+- `fetchMessage()` and `fetchMessageBody()` now verify UID in response to prevent returning wrong data (#2)
+
 ### Deprecated
 - `listMessages()` - use `listMessageUIDs()` instead (sequence numbers are unstable)
 

--- a/Sources/SwiftIMAP/IMAPClient+Fetch.swift
+++ b/Sources/SwiftIMAP/IMAPClient+Fetch.swift
@@ -83,12 +83,17 @@ extension IMAPClient {
 
     /// Fetches a message by its UID.
     ///
+    /// - Note: UID is automatically included in fetch items if not present, to verify
+    ///   the response matches the requested message.
+    ///
     /// - Parameters:
     ///   - uid: The UID of the message to fetch
     ///   - mailbox: The mailbox containing the message
     ///   - items: The fetch items to request (defaults to common envelope data)
-    /// - Returns: The message summary if found, nil otherwise
-    /// - Throws: `IMAPError` if the connection fails or the mailbox cannot be selected.
+    /// - Returns: The message summary if found with matching UID, nil if not found
+    ///   or if server returned responses with non-matching UIDs
+    /// - Throws: `IMAPError` for connection failures, mailbox selection errors,
+    ///   command failures, or if the response cannot be parsed.
     public func fetchMessage(
         uid: UID,
         in mailbox: String,
@@ -105,7 +110,9 @@ extension IMAPClient {
             work: {
                 _ = try await self.selectMailbox(mailbox)
 
-                // Ensure UID is included in fetch items for verification
+                // Ensure UID is included in fetch items so we can verify the response.
+                // Without the UID in the response, we cannot confirm we received the
+                // correct message when concurrent fetches are in flight.
                 let hasUID = items.contains { item in
                     if case .uid = item { return true }
                     return false
@@ -121,8 +128,9 @@ extension IMAPClient {
 
                 for response in responses {
                     if case .untagged(.fetch(let seqNum, let attributes)) = response {
-                        // Verify the UID in the response matches the requested UID
-                        // to avoid returning wrong data when multiple fetches are pending
+                        // Verify the UID in the response matches the requested UID.
+                        // Concurrent fetch requests may receive interleaved responses,
+                        // so we must filter to find the correct one.
                         let responseUID = attributes.compactMap { attribute -> UID? in
                             if case .uid(let fetchedUID) = attribute {
                                 return fetchedUID
@@ -130,10 +138,15 @@ extension IMAPClient {
                             return nil
                         }.first
 
-                        if responseUID == uid {
-                            return try self.parseMessageSummary(sequenceNumber: seqNum, attributes: attributes)
+                        if let responseUID = responseUID {
+                            if responseUID == uid {
+                                return try self.parseMessageSummary(sequenceNumber: seqNum, attributes: attributes)
+                            } else {
+                                self.logger.debug("UID mismatch in fetchMessage: requested \(uid), received \(responseUID) - skipping response")
+                            }
+                        } else {
+                            self.logger.warning("FETCH response missing UID attribute for request UID \(uid)")
                         }
-                        // UID doesn't match - skip this response
                     }
                 }
 
@@ -184,10 +197,15 @@ extension IMAPClient {
 
                 // Only return body if UID matches the requested UID
                 // This prevents returning wrong data when multiple fetches are pending
-                if responseUID == uid, let data = bodyData {
-                    return data
+                if let responseUID = responseUID {
+                    if responseUID == uid, let data = bodyData {
+                        return data
+                    } else if responseUID != uid {
+                        self.logger.debug("UID mismatch in fetchMessageBody: requested \(uid), received \(responseUID) - skipping response")
+                    }
+                } else {
+                    self.logger.warning("FETCH response missing UID attribute for request UID \(uid)")
                 }
-                // UID doesn't match - skip this response
             }
         }
 

--- a/Sources/SwiftIMAP/IMAPClient+Fetch.swift
+++ b/Sources/SwiftIMAP/IMAPClient+Fetch.swift
@@ -81,6 +81,14 @@ extension IMAPClient {
         )
     }
 
+    /// Fetches a message by its UID.
+    ///
+    /// - Parameters:
+    ///   - uid: The UID of the message to fetch
+    ///   - mailbox: The mailbox containing the message
+    ///   - items: The fetch items to request (defaults to common envelope data)
+    /// - Returns: The message summary if found, nil otherwise
+    /// - Throws: `IMAPError` if the connection fails or the mailbox cannot be selected.
     public func fetchMessage(
         uid: UID,
         in mailbox: String,
@@ -97,13 +105,35 @@ extension IMAPClient {
             work: {
                 _ = try await self.selectMailbox(mailbox)
 
+                // Ensure UID is included in fetch items for verification
+                let hasUID = items.contains { item in
+                    if case .uid = item { return true }
+                    return false
+                }
+                var fetchItems = items
+                if !hasUID {
+                    fetchItems.insert(.uid, at: 0)
+                }
+
                 let responses = try await self.connection.sendCommand(
-                    .uid(.fetch(sequence: .single(uid), items: items))
+                    .uid(.fetch(sequence: .single(uid), items: fetchItems))
                 )
 
                 for response in responses {
                     if case .untagged(.fetch(let seqNum, let attributes)) = response {
-                        return try self.parseMessageSummary(sequenceNumber: seqNum, attributes: attributes)
+                        // Verify the UID in the response matches the requested UID
+                        // to avoid returning wrong data when multiple fetches are pending
+                        let responseUID = attributes.compactMap { attribute -> UID? in
+                            if case .uid(let fetchedUID) = attribute {
+                                return fetchedUID
+                            }
+                            return nil
+                        }.first
+
+                        if responseUID == uid {
+                            return try self.parseMessageSummary(sequenceNumber: seqNum, attributes: attributes)
+                        }
+                        // UID doesn't match - skip this response
                     }
                 }
 
@@ -112,6 +142,14 @@ extension IMAPClient {
         )
     }
 
+    /// Fetches the body of a message by its UID.
+    ///
+    /// - Parameters:
+    ///   - uid: The UID of the message to fetch
+    ///   - mailbox: The mailbox containing the message
+    ///   - peek: If true, fetching won't mark the message as read (default: true)
+    /// - Returns: The message body data if found, nil otherwise
+    /// - Throws: `IMAPError` if the connection fails or the mailbox cannot be selected.
     public func fetchMessageBody(
         uid: UID,
         in mailbox: String,
@@ -119,23 +157,37 @@ extension IMAPClient {
     ) async throws -> Data? {
         _ = try await selectMailbox(mailbox)
 
+        // Request UID along with body for verification
         let responses = try await connection.sendCommand(
             .uid(.fetch(
                 sequence: .single(uid),
-                items: [.bodySection(section: nil, peek: peek)]
+                items: [.uid, .bodySection(section: nil, peek: peek)]
             ))
         )
 
         for response in responses {
             if case .untagged(.fetch(_, let attributes)) = response {
+                // Extract UID from response for verification
+                var responseUID: UID?
+                var bodyData: Data?
+
                 for attribute in attributes {
                     switch attribute {
+                    case .uid(let fetchedUID):
+                        responseUID = fetchedUID
                     case .body(_, _, let data), .bodyPeek(_, _, let data):
-                        return data
+                        bodyData = data
                     default:
                         continue
                     }
                 }
+
+                // Only return body if UID matches the requested UID
+                // This prevents returning wrong data when multiple fetches are pending
+                if responseUID == uid, let data = bodyData {
+                    return data
+                }
+                // UID doesn't match - skip this response
             }
         }
 

--- a/Tests/SwiftIMAPTests/GreenMailIntegrationTests.swift
+++ b/Tests/SwiftIMAPTests/GreenMailIntegrationTests.swift
@@ -636,6 +636,122 @@ final class GreenMailIntegrationTests: XCTestCase {
             try await client.expunge(uids: [remainingUID], in: mailbox)
         }
     }
+
+    // MARK: - Fetch UID Verification Tests (Issue #2)
+
+    /// Test that fetchMessage returns the correct message when multiple messages exist
+    func testFetchMessageReturnsCorrectMessageByUID() async throws {
+        let client = try await connectClient()
+        defer { Task { await client.disconnect() } }
+
+        let mailbox = "INBOX"
+        let subject1 = "Fetch-UID-Test-1-\(UUID().uuidString)"
+        let subject2 = "Fetch-UID-Test-2-\(UUID().uuidString)"
+
+        // Append two test messages with different subjects
+        let message1 = """
+        From: sender@example.com\r
+        To: test@example.com\r
+        Subject: \(subject1)\r
+        \r
+        Body of message 1.
+        """
+        let message2 = """
+        From: sender@example.com\r
+        To: test@example.com\r
+        Subject: \(subject2)\r
+        \r
+        Body of message 2.
+        """
+        try await client.appendMessage(Data(message1.utf8), to: mailbox)
+        try await client.appendMessage(Data(message2.utf8), to: mailbox)
+
+        // Get UIDs for both messages
+        let uids1 = try await client.searchMessagesBySubject(subject1, in: mailbox)
+        let uids2 = try await client.searchMessagesBySubject(subject2, in: mailbox)
+
+        guard let uid1 = uids1.first?.uid, let uid2 = uids2.first?.uid else {
+            XCTFail("Could not find test messages")
+            return
+        }
+
+        // Fetch each message by UID and verify we get the correct one
+        let fetched1 = try await client.fetchMessage(uid: uid1, in: mailbox)
+        let fetched2 = try await client.fetchMessage(uid: uid2, in: mailbox)
+
+        XCTAssertNotNil(fetched1, "Should fetch message 1")
+        XCTAssertNotNil(fetched2, "Should fetch message 2")
+        XCTAssertEqual(fetched1?.uid, uid1, "Fetched message 1 should have correct UID")
+        XCTAssertEqual(fetched2?.uid, uid2, "Fetched message 2 should have correct UID")
+        XCTAssertEqual(fetched1?.envelope?.subject, subject1, "Fetched message 1 should have correct subject")
+        XCTAssertEqual(fetched2?.envelope?.subject, subject2, "Fetched message 2 should have correct subject")
+
+        // Clean up
+        try await client.storeFlags(uids: [uid1, uid2], in: mailbox, flags: [.deleted], action: .add)
+        try await client.expunge(uids: [uid1, uid2], in: mailbox)
+    }
+
+    /// Test that fetchMessageBody returns the correct body when multiple messages exist
+    func testFetchMessageBodyReturnsCorrectBodyByUID() async throws {
+        let client = try await connectClient()
+        defer { Task { await client.disconnect() } }
+
+        let mailbox = "INBOX"
+        let subject1 = "Body-UID-Test-1-\(UUID().uuidString)"
+        let subject2 = "Body-UID-Test-2-\(UUID().uuidString)"
+        let body1 = "Unique body content for message ONE - \(UUID().uuidString)"
+        let body2 = "Unique body content for message TWO - \(UUID().uuidString)"
+
+        // Append two test messages with different bodies
+        let message1 = """
+        From: sender@example.com\r
+        To: test@example.com\r
+        Subject: \(subject1)\r
+        \r
+        \(body1)
+        """
+        let message2 = """
+        From: sender@example.com\r
+        To: test@example.com\r
+        Subject: \(subject2)\r
+        \r
+        \(body2)
+        """
+        try await client.appendMessage(Data(message1.utf8), to: mailbox)
+        try await client.appendMessage(Data(message2.utf8), to: mailbox)
+
+        // Get UIDs for both messages
+        let uids1 = try await client.searchMessagesBySubject(subject1, in: mailbox)
+        let uids2 = try await client.searchMessagesBySubject(subject2, in: mailbox)
+
+        guard let uid1 = uids1.first?.uid, let uid2 = uids2.first?.uid else {
+            XCTFail("Could not find test messages")
+            return
+        }
+
+        // Fetch each body by UID and verify we get the correct one
+        let fetchedBody1 = try await client.fetchMessageBody(uid: uid1, in: mailbox)
+        let fetchedBody2 = try await client.fetchMessageBody(uid: uid2, in: mailbox)
+
+        XCTAssertNotNil(fetchedBody1, "Should fetch body 1")
+        XCTAssertNotNil(fetchedBody2, "Should fetch body 2")
+
+        if let data1 = fetchedBody1, let bodyString1 = String(data: data1, encoding: .utf8) {
+            XCTAssertTrue(bodyString1.contains(body1), "Fetched body 1 should contain correct content")
+        } else {
+            XCTFail("Could not decode body 1")
+        }
+
+        if let data2 = fetchedBody2, let bodyString2 = String(data: data2, encoding: .utf8) {
+            XCTAssertTrue(bodyString2.contains(body2), "Fetched body 2 should contain correct content")
+        } else {
+            XCTFail("Could not decode body 2")
+        }
+
+        // Clean up
+        try await client.storeFlags(uids: [uid1, uid2], in: mailbox, flags: [.deleted], action: .add)
+        try await client.expunge(uids: [uid1, uid2], in: mailbox)
+    }
 }
 
 private extension GreenMailIntegrationTests {

--- a/Tests/SwiftIMAPTests/IMAPClientFetchUIDVerificationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPClientFetchUIDVerificationTests.swift
@@ -166,6 +166,37 @@ final class IMAPClientFetchUIDVerificationTests: XCTestCase {
 
     // MARK: - Request UID in response tests
 
+    /// Test that fetchMessage automatically adds UID to fetch items if not present
+    func testFetchMessageEnsuresUIDInRequest() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        mockServer.setResponse(for: "UID FETCH", response: """
+* 1 FETCH (UID 42 FLAGS (\\Seen) INTERNALDATE "17-Jul-1996 02:44:25 -0700" RFC822.SIZE 4286 ENVELOPE ("Wed, 17 Jul 1996 02:23:25 -0700" "Test Subject" ((NIL NIL "sender" "example.com")) ((NIL NIL "sender" "example.com")) ((NIL NIL "sender" "example.com")) ((NIL NIL "recipient" "example.com")) NIL NIL NIL "<msg@example.com>"))
+""")
+
+        let client = makeClient()
+        try await client.connect()
+
+        // Request without UID in items - it should be added automatically
+        _ = try await client.fetchMessage(uid: 42, in: "INBOX", items: [.flags, .envelope])
+
+        // Verify the fetch command includes UID in the requested items
+        let commands = mockServer.receivedCommands.map { $0.uppercased() }
+        let fetchCommand = commands.first { $0.contains("UID FETCH") && $0.contains("ENVELOPE") }
+        XCTAssertNotNil(fetchCommand)
+
+        // The fetch should request UID even though we didn't include it in items
+        if let cmd = fetchCommand {
+            // Command format: "A4 UID FETCH 42 (UID FLAGS ENVELOPE)"
+            // Check that UID appears in the fetch items list (between parentheses)
+            XCTAssertTrue(cmd.contains("(UID") || cmd.contains(" UID ") || cmd.contains(" UID)"),
+                          "fetchMessage should add UID to fetch items for verification. Command: \(cmd)")
+        }
+
+        await client.disconnect()
+    }
+
     /// Test that fetchMessageBody requests UID in fetch items
     func testFetchMessageBodyIncludesUIDInRequest() async throws {
         mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")

--- a/Tests/SwiftIMAPTests/IMAPClientFetchUIDVerificationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPClientFetchUIDVerificationTests.swift
@@ -214,9 +214,11 @@ final class IMAPClientFetchUIDVerificationTests: XCTestCase {
         let fetchCommand = commands.first { $0.contains("UID FETCH") && $0.contains("BODY") }
         XCTAssertNotNil(fetchCommand)
 
-        // The fetch should request both UID and BODY
+        // The fetch should request UID in the items list (not just as command prefix)
+        // Command format: "A4 UID FETCH 42 (UID BODY[])"
         if let cmd = fetchCommand {
-            XCTAssertTrue(cmd.contains("UID") && cmd.contains("BODY"),
+            // Check that UID appears in the fetch items list (between parentheses)
+            XCTAssertTrue(cmd.contains("(UID") || cmd.contains(" UID ") || cmd.contains(" UID)"),
                           "fetchMessageBody should request UID in fetch items for verification. Command: \(cmd)")
         }
 

--- a/Tests/SwiftIMAPTests/IMAPClientFetchUIDVerificationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPClientFetchUIDVerificationTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+@testable import SwiftIMAP
+import NIO
+
+/// Tests for Issue #2: fetchMessageBody and fetchMessage must verify UID in response
+/// matches the requested UID to avoid returning wrong data when multiple fetches are pending.
+final class IMAPClientFetchUIDVerificationTests: XCTestCase {
+    private var eventLoopGroup: MultiThreadedEventLoopGroup!
+    private var mockServer: MockIMAPServer!
+    private var serverPort: Int!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        mockServer = MockIMAPServer(eventLoopGroup: eventLoopGroup)
+        serverPort = try await mockServer.start()
+    }
+
+    override func tearDown() async throws {
+        if let mockServer {
+            try await mockServer.shutdown()
+            self.mockServer = nil
+        }
+        if let eventLoopGroup {
+            try await eventLoopGroup.shutdownGracefully()
+            self.eventLoopGroup = nil
+        }
+        serverPort = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - fetchMessageBody UID Verification Tests
+
+    /// Test that fetchMessageBody returns correct body when UID matches
+    func testFetchMessageBodyReturnsCorrectBodyWhenUIDMatches() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        // Response includes UID that matches the requested UID
+        mockServer.setResponse(for: "UID FETCH", response: "* 1 FETCH (UID 42 BODY[] {5}\r\nHello)")
+
+        let client = makeClient()
+        try await client.connect()
+
+        let body = try await client.fetchMessageBody(uid: 42, in: "INBOX")
+        let bodyString = body.flatMap { String(data: $0, encoding: .utf8) }
+
+        XCTAssertEqual(bodyString, "Hello")
+
+        await client.disconnect()
+    }
+
+    /// Test that fetchMessageBody returns nil when UID doesn't match
+    /// This simulates the race condition where a response for a different UID is received
+    func testFetchMessageBodyReturnsNilWhenUIDMismatch() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        // Response UID (999) doesn't match requested UID (42)
+        mockServer.setResponse(for: "UID FETCH", response: "* 1 FETCH (UID 999 BODY[] {5}\r\nWrong)")
+
+        let client = makeClient()
+        try await client.connect()
+
+        // Request UID 42, but server returns UID 999 (simulating race condition)
+        let body = try await client.fetchMessageBody(uid: 42, in: "INBOX")
+
+        // Should return nil because UID doesn't match, NOT the wrong body
+        XCTAssertNil(body, "fetchMessageBody should return nil when response UID doesn't match requested UID")
+
+        await client.disconnect()
+    }
+
+    /// Test that fetchMessageBody finds correct body among multiple responses
+    func testFetchMessageBodyFindsCorrectBodyAmongMultipleResponses() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        // Multiple FETCH responses with different UIDs
+        mockServer.setResponse(for: "UID FETCH", response: """
+* 1 FETCH (UID 100 BODY[] {5}\r\nFirst)
+* 2 FETCH (UID 42 BODY[] {7}\r\nCorrect)
+* 3 FETCH (UID 200 BODY[] {4}\r\nLast)
+""")
+
+        let client = makeClient()
+        try await client.connect()
+
+        // Request UID 42, should find the correct response
+        let body = try await client.fetchMessageBody(uid: 42, in: "INBOX")
+        let bodyString = body.flatMap { String(data: $0, encoding: .utf8) }
+
+        XCTAssertEqual(bodyString, "Correct", "Should find and return body for matching UID 42")
+
+        await client.disconnect()
+    }
+
+    // MARK: - fetchMessage UID Verification Tests
+
+    /// Test that fetchMessage returns correct message when UID matches
+    func testFetchMessageReturnsCorrectMessageWhenUIDMatches() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        mockServer.setResponse(for: "UID FETCH", response: """
+* 1 FETCH (UID 42 FLAGS (\\Seen) INTERNALDATE "17-Jul-1996 02:44:25 -0700" RFC822.SIZE 4286 ENVELOPE ("Wed, 17 Jul 1996 02:23:25 -0700" "Correct Subject" ((NIL NIL "sender" "example.com")) ((NIL NIL "sender" "example.com")) ((NIL NIL "sender" "example.com")) ((NIL NIL "recipient" "example.com")) NIL NIL NIL "<msg@example.com>"))
+""")
+
+        let client = makeClient()
+        try await client.connect()
+
+        let message = try await client.fetchMessage(uid: 42, in: "INBOX")
+
+        XCTAssertNotNil(message)
+        XCTAssertEqual(message?.uid, 42)
+        XCTAssertEqual(message?.envelope?.subject, "Correct Subject")
+
+        await client.disconnect()
+    }
+
+    /// Test that fetchMessage returns nil when UID doesn't match
+    func testFetchMessageReturnsNilWhenUIDMismatch() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        // Response UID (999) doesn't match requested UID (42)
+        mockServer.setResponse(for: "UID FETCH", response: """
+* 1 FETCH (UID 999 FLAGS () INTERNALDATE "17-Jul-1996 02:44:25 -0700" RFC822.SIZE 100 ENVELOPE ("Wed, 17 Jul 1996 02:23:25 -0700" "Wrong Message" ((NIL NIL "wrong" "example.com")) NIL NIL NIL NIL NIL NIL "<wrong@example.com>"))
+""")
+
+        let client = makeClient()
+        try await client.connect()
+
+        // Request UID 42, but server returns UID 999
+        let message = try await client.fetchMessage(uid: 42, in: "INBOX")
+
+        XCTAssertNil(message, "fetchMessage should return nil when response UID doesn't match requested UID")
+
+        await client.disconnect()
+    }
+
+    /// Test that fetchMessage finds correct message among multiple responses
+    func testFetchMessageFindsCorrectMessageAmongMultipleResponses() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        // Multiple FETCH responses with different UIDs
+        mockServer.setResponse(for: "UID FETCH", response: """
+* 1 FETCH (UID 100 FLAGS () INTERNALDATE "17-Jul-1996 02:44:25 -0700" RFC822.SIZE 100 ENVELOPE ("Wed, 17 Jul 1996 02:23:25 -0700" "First" ((NIL NIL "first" "example.com")) NIL NIL NIL NIL NIL NIL "<first@example.com>"))
+* 2 FETCH (UID 42 FLAGS (\\Seen) INTERNALDATE "18-Jul-1996 02:44:25 -0700" RFC822.SIZE 200 ENVELOPE ("Thu, 18 Jul 1996 02:23:25 -0700" "Target Message" ((NIL NIL "target" "example.com")) NIL NIL NIL NIL NIL NIL "<target@example.com>"))
+* 3 FETCH (UID 200 FLAGS () INTERNALDATE "19-Jul-1996 02:44:25 -0700" RFC822.SIZE 300 ENVELOPE ("Fri, 19 Jul 1996 02:23:25 -0700" "Last" ((NIL NIL "last" "example.com")) NIL NIL NIL NIL NIL NIL "<last@example.com>"))
+""")
+
+        let client = makeClient()
+        try await client.connect()
+
+        // Request UID 42, should find the correct response
+        let message = try await client.fetchMessage(uid: 42, in: "INBOX")
+
+        XCTAssertNotNil(message)
+        XCTAssertEqual(message?.uid, 42)
+        XCTAssertEqual(message?.envelope?.subject, "Target Message")
+
+        await client.disconnect()
+    }
+
+    // MARK: - Request UID in response tests
+
+    /// Test that fetchMessageBody requests UID in fetch items
+    func testFetchMessageBodyIncludesUIDInRequest() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        mockServer.setResponse(for: "UID FETCH", response: "* 1 FETCH (UID 42 BODY[] {5}\r\nHello)")
+
+        let client = makeClient()
+        try await client.connect()
+
+        _ = try await client.fetchMessageBody(uid: 42, in: "INBOX")
+
+        // Verify the fetch command includes UID in the requested items
+        let commands = mockServer.receivedCommands.map { $0.uppercased() }
+        let fetchCommand = commands.first { $0.contains("UID FETCH") && $0.contains("BODY") }
+        XCTAssertNotNil(fetchCommand)
+
+        // The fetch should request both UID and BODY
+        if let cmd = fetchCommand {
+            XCTAssertTrue(cmd.contains("UID") && cmd.contains("BODY"),
+                          "fetchMessageBody should request UID in fetch items for verification. Command: \(cmd)")
+        }
+
+        await client.disconnect()
+    }
+
+    // MARK: - Helpers
+
+    private func makeClient() -> IMAPClient {
+        IMAPClient(
+            configuration: IMAPConfiguration(
+                hostname: "localhost",
+                port: serverPort,
+                tlsMode: .disabled,
+                authMethod: .login(username: "testuser", password: "testpass")
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix `fetchMessageBody()`** to verify UID in response before returning body data
- **Fix `fetchMessage()`** to verify UID in response before returning message summary
- **Request UID in fetch items** to ensure verification is possible
- **Add 7 comprehensive tests** for UID verification behavior

## Problem

When multiple UID FETCH commands are pending simultaneously, untagged FETCH responses get routed to ALL pending commands (see `ConnectionActor.swift` lines 434-443). Methods that returned the first body/data found without verifying the UID would return wrong data.

**Race condition scenario:**
```swift
await withTaskGroup(of: Void.self) { group in
    for message in messages {
        group.addTask {
            // These run concurrently, creating multiple pending UID FETCH commands
            let body = try await client.fetchMessageBody(uid: message.uid, in: mailbox, peek: true)
            // body may contain wrong message's content!
        }
    }
}
```

## Solution

Both `fetchMessageBody()` and `fetchMessage()` now:
1. Request `.uid` in the fetch items so the UID is included in the response
2. Extract the UID from each FETCH response's attributes
3. Compare it against the requested UID
4. Only return data when the UID matches, skip mismatched responses

## Test plan

- [x] Added `IMAPClientFetchUIDVerificationTests.swift` with 7 tests:
  - `testFetchMessageBodyReturnsCorrectBodyWhenUIDMatches`
  - `testFetchMessageBodyReturnsNilWhenUIDMismatch`
  - `testFetchMessageBodyFindsCorrectBodyAmongMultipleResponses`
  - `testFetchMessageReturnsCorrectMessageWhenUIDMatches`
  - `testFetchMessageReturnsNilWhenUIDMismatch`
  - `testFetchMessageFindsCorrectMessageAmongMultipleResponses`
  - `testFetchMessageBodyIncludesUIDInRequest`
- [x] All 207 tests pass
- [x] Verified existing tests still work

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)