### PR TITLE
Fix MimePart.isAttachment to handle inline parts with filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `fetchMessage()` and `fetchMessageBody()` now verify UID in response to prevent returning wrong data (#2)
+- `MimePart.isAttachment` now correctly identifies inline parts with filenames as attachments (#5)
+  - Apple Mail marks PDF attachments as `Content-Disposition: inline` with a filename
+  - Previously these were incorrectly excluded from the `attachments` array
+  - Embedded images with Content-ID (cid: references) are still excluded, even with filenames
 
 ### Deprecated
 - `listMessages()` - use `listMessageUIDs()` instead (sequence numbers are unstable)

--- a/Sources/SwiftIMAP/Models/MessageSummary+MIME.swift
+++ b/Sources/SwiftIMAP/Models/MessageSummary+MIME.swift
@@ -231,7 +231,15 @@ public struct MimePart {
     
     /// Check if this part is an attachment
     public var isAttachment: Bool {
-        if isInline {
+        // Inline parts WITHOUT a filename are truly embedded (e.g., cid: referenced images)
+        if isInline && filename == nil {
+            return false
+        }
+
+        // Inline images with Content-ID are embedded via cid: references in HTML
+        // These should not be treated as attachments even if they have a filename
+        if isInline, let mimeType = mimeType?.lowercased(),
+           mimeType.hasPrefix("image/"), contentID != nil {
             return false
         }
 

--- a/Tests/SwiftIMAPTests/MIMEParsingAdditionalTests.swift
+++ b/Tests/SwiftIMAPTests/MIMEParsingAdditionalTests.swift
@@ -35,7 +35,9 @@ final class MIMEParsingAdditionalTests: XCTestCase {
         XCTAssertEqual(parsed?.plainTextContent, "Hello World")
     }
 
-    func testInlineDispositionOverridesAttachment() throws {
+    func testInlinePartWithFilenameIsAttachment() throws {
+        // Issue #5: Inline parts WITH a filename should be treated as attachments
+        // (e.g., Apple Mail marks PDF attachments as inline with filename)
         let messageData = """
         From: sender@example.com
         To: recipient@example.com
@@ -54,7 +56,42 @@ final class MIMEParsingAdditionalTests: XCTestCase {
         XCTAssertEqual(part?.mimeType, "image/png")
         XCTAssertEqual(part?.filename, "inline.png")
         XCTAssertTrue(part?.isInline ?? false)
-        XCTAssertFalse(part?.isAttachment ?? true)
+        XCTAssertTrue(part?.isAttachment ?? false)  // Changed: inline WITH filename IS attachment
+        XCTAssertEqual(parsed?.attachments.count, 1)
+    }
+
+    func testInlinePartWithoutFilenameIsNotAttachment() throws {
+        // Truly embedded content (e.g., cid: referenced images) should NOT be attachments
+        let boundary = "boundary"
+        let messageData = """
+        From: sender@example.com
+        To: recipient@example.com
+        Subject: Inline Image
+        Content-Type: multipart/related; boundary="\(boundary)"
+
+        --\(boundary)
+        Content-Type: text/html
+
+        <html><body><img src="cid:img1"></body></html>
+        --\(boundary)
+        Content-Type: image/png
+        Content-Disposition: inline
+        Content-ID: <img1>
+        Content-Transfer-Encoding: base64
+
+        AAA=
+        --\(boundary)--
+        """.data(using: .utf8)!
+
+        let summary = makeSummary()
+        let parsed = try summary.parseMimeContent(from: messageData)
+        let inlinePart = parsed?.parts.first { $0.contentID != nil }
+
+        XCTAssertNotNil(inlinePart)
+        XCTAssertTrue(inlinePart?.isInline ?? false)
+        XCTAssertNil(inlinePart?.filename)
+        XCTAssertFalse(inlinePart?.isAttachment ?? true)  // No filename = NOT attachment
+        XCTAssertEqual(parsed?.attachments.count, 0)
     }
 
     func testAttachmentDetectedByContentTypeWithoutDisposition() throws {
@@ -94,6 +131,66 @@ final class MIMEParsingAdditionalTests: XCTestCase {
         let part = parsed?.parts.first
 
         XCTAssertEqual(part?.decodedText, "NotBase64!!")
+    }
+
+    func testInlineImageWithContentIdIsNotAttachment() throws {
+        // Edge case: inline image WITH filename but also Content-ID
+        // These are embedded via cid: in HTML and should NOT be attachments
+        let boundary = "boundary"
+        let messageData = """
+        From: sender@example.com
+        To: recipient@example.com
+        Subject: Email with embedded logo
+        Content-Type: multipart/related; boundary="\(boundary)"
+
+        --\(boundary)
+        Content-Type: text/html
+
+        <html><body><img src="cid:logo"></body></html>
+        --\(boundary)
+        Content-Type: image/png; name="company-logo.png"
+        Content-Disposition: inline; filename="company-logo.png"
+        Content-ID: <logo>
+        Content-Transfer-Encoding: base64
+
+        AAA=
+        --\(boundary)--
+        """.data(using: .utf8)!
+
+        let summary = makeSummary()
+        let parsed = try summary.parseMimeContent(from: messageData)
+        let imagePart = parsed?.parts.first { $0.contentID != nil }
+
+        XCTAssertNotNil(imagePart)
+        XCTAssertEqual(imagePart?.filename, "company-logo.png")
+        XCTAssertEqual(imagePart?.contentID, "<logo>")
+        XCTAssertTrue(imagePart?.isInline ?? false)
+        XCTAssertFalse(imagePart?.isAttachment ?? true)  // Has Content-ID = embedded, not attachment
+        XCTAssertEqual(parsed?.attachments.count, 0)
+    }
+
+    func testAppleMailInlinePdfIsAttachment() throws {
+        // Real-world case from issue #5: Apple Mail marks PDFs as inline with filename
+        let messageData = """
+        From: sender@example.com
+        To: recipient@example.com
+        Subject: Apple Mail PDF
+        Content-Type: application/pdf; x-unix-mode=0644; name="document.pdf"
+        Content-Disposition: inline; filename="document.pdf"
+        Content-Transfer-Encoding: base64
+
+        JVBERi0xLjQKJeLjz9MKCg==
+        """.data(using: .utf8)!
+
+        let summary = makeSummary()
+        let parsed = try summary.parseMimeContent(from: messageData)
+        let part = parsed?.parts.first
+
+        XCTAssertEqual(part?.filename, "document.pdf")
+        XCTAssertEqual(part?.mimeType, "application/pdf")
+        XCTAssertTrue(part?.isInline ?? false)
+        XCTAssertTrue(part?.isAttachment ?? false)
+        XCTAssertEqual(parsed?.attachments.count, 1)
     }
 
     private func makeSummary() -> MessageSummary {


### PR DESCRIPTION
## Summary

Fixes `MimePart.isAttachment` incorrectly returning `false` for inline parts that have filenames (e.g., Apple Mail PDFs).

> **Note:** This PR is rebased on #6 (SwiftLint threshold changes) to pass CI.

## Changes

Updated `isAttachment` logic to handle three cases:

| Disposition | Filename | Content-ID | isAttachment |
|-------------|----------|------------|--------------|
| `inline` | none | any | `false` (embedded content) |
| `inline` | present | image/* + has CID | `false` (cid: embedded image) |
| `inline` | present | other | `true` (downloadable) |
| `attachment` | any | any | `true` |

## Code Changes

```swift
// Before: excluded ALL inline parts
if isInline { return false }

// After: nuanced handling
if isInline && filename == nil { return false }
if isInline, mimeType.hasPrefix("image/"), contentID != nil { return false }
```

## Tests Added

- `testInlinePartWithFilenameIsAttachment` - PNG with filename, no CID
- `testInlinePartWithoutFilenameIsNotAttachment` - truly embedded content
- `testInlineImageWithContentIdIsNotAttachment` - image with filename AND CID
- `testAppleMailInlinePdfIsAttachment` - real-world Apple Mail PDF case

## Test plan

- [x] All 203 tests pass locally
- [x] Red/green TDD approach used
- [x] Matches MailTriage workaround logic (can be reverted there after merge)

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)