### PR TITLE
Add References header support to MessageSummary

### DIFF
--- a/Sources/SwiftIMAP/IMAPClient+Parsing.swift
+++ b/Sources/SwiftIMAP/IMAPClient+Parsing.swift
@@ -10,6 +10,7 @@ extension IMAPClient {
         var internalDate: Date?
         var size: UInt32?
         var envelope: Envelope?
+        var references: String?
 
         for attribute in attributes {
             switch attribute {
@@ -23,6 +24,11 @@ extension IMAPClient {
                 size = sizeValue
             case .envelope(let env):
                 envelope = parseEnvelope(env)
+            case .headerFields(let fields, let data):
+                // Parse References header if present
+                if fields.contains(where: { $0.uppercased() == "REFERENCES" }) {
+                    references = parseReferencesHeader(from: data)
+                }
             default:
                 break
             }
@@ -40,8 +46,29 @@ extension IMAPClient {
             flags: flags,
             internalDate: internalDate,
             size: size,
-            envelope: envelope
+            envelope: envelope,
+            references: references
         )
+    }
+
+    /// Parse the References header value from raw header data.
+    /// The data format is: "References: <id1> <id2> ...\r\n"
+    private func parseReferencesHeader(from data: Data) -> String? {
+        guard let headerText = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        // Find the References header line and extract its value
+        let lines = headerText.components(separatedBy: "\r\n")
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.lowercased().hasPrefix("references:") {
+                let value = String(trimmed.dropFirst("references:".count))
+                    .trimmingCharacters(in: .whitespaces)
+                return value.isEmpty ? nil : value
+            }
+        }
+        return nil
     }
 
     func parseEnvelope(_ data: IMAPResponse.EnvelopeData) -> Envelope {

--- a/Sources/SwiftIMAP/IMAPClient+Parsing.swift
+++ b/Sources/SwiftIMAP/IMAPClient+Parsing.swift
@@ -52,15 +52,24 @@ extension IMAPClient {
     }
 
     /// Parse the References header value from raw header data.
-    /// The data format is: "References: <id1> <id2> ...\r\n"
-    private func parseReferencesHeader(from data: Data) -> String? {
-        guard let headerText = String(data: data, encoding: .utf8) else {
+    /// The data format is: "References: <id1> <id2> ...\r\n", optionally RFC 5322
+    /// folded across multiple lines with CRLF followed by WSP continuations.
+    func parseReferencesHeader(from data: Data) -> String? {
+        let headerText: String
+        if let utf8 = String(data: data, encoding: .utf8) {
+            headerText = utf8
+        } else if let latin1 = String(data: data, encoding: .isoLatin1) {
+            headerText = latin1
+        } else {
             return nil
         }
 
-        // Find the References header line and extract its value
-        let lines = headerText.components(separatedBy: "\r\n")
-        for line in lines {
+        // RFC 5322 header unfolding: CRLF followed by WSP is a line continuation.
+        let unfolded = headerText
+            .replacingOccurrences(of: "\r\n ", with: " ")
+            .replacingOccurrences(of: "\r\n\t", with: " ")
+
+        for line in unfolded.components(separatedBy: "\r\n") {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if trimmed.lowercased().hasPrefix("references:") {
                 let value = String(trimmed.dropFirst("references:".count))

--- a/Sources/SwiftIMAP/Models/Message.swift
+++ b/Sources/SwiftIMAP/Models/Message.swift
@@ -10,14 +10,18 @@ public struct MessageSummary: Sendable {
     public let internalDate: Date
     public let size: UInt32
     public let envelope: Envelope?
-    
+    /// The References header, containing message IDs for threading.
+    /// This is fetched separately from the envelope via BODY.PEEK[HEADER.FIELDS (REFERENCES)].
+    public let references: String?
+
     public init(
         uid: UID,
         sequenceNumber: MessageSequenceNumber,
         flags: Set<Flag> = [],
         internalDate: Date,
         size: UInt32,
-        envelope: Envelope? = nil
+        envelope: Envelope? = nil,
+        references: String? = nil
     ) {
         self.uid = uid
         self.sequenceNumber = sequenceNumber
@@ -25,6 +29,7 @@ public struct MessageSummary: Sendable {
         self.internalDate = internalDate
         self.size = size
         self.envelope = envelope
+        self.references = references
     }
 }
 

--- a/Sources/SwiftIMAP/Models/Message.swift
+++ b/Sources/SwiftIMAP/Models/Message.swift
@@ -11,7 +11,8 @@ public struct MessageSummary: Sendable {
     public let size: UInt32
     public let envelope: Envelope?
     /// The References header, containing message IDs for threading.
-    /// This is fetched separately from the envelope via BODY.PEEK[HEADER.FIELDS (REFERENCES)].
+    /// Populated when the fetch includes a `BODY[HEADER.FIELDS (REFERENCES)]`
+    /// item (with or without `.PEEK`).
     public let references: String?
 
     public init(

--- a/Tests/SwiftIMAPTests/IMAPClientReferencesHeaderTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPClientReferencesHeaderTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import SwiftIMAP
+
+final class IMAPClientReferencesHeaderTests: XCTestCase {
+    private func makeClient() -> IMAPClient {
+        let config = IMAPConfiguration(
+            hostname: "example.com",
+            authMethod: .login(username: "user", password: "pass")
+        )
+        return IMAPClient(configuration: config)
+    }
+
+    func testParsesSingleReference() {
+        let client = makeClient()
+        let raw = "References: <abc@example.com>\r\n\r\n"
+        let data = Data(raw.utf8)
+
+        XCTAssertEqual(client.parseReferencesHeader(from: data), "<abc@example.com>")
+    }
+
+    func testParsesMultipleReferencesOnSingleLine() {
+        let client = makeClient()
+        let raw = "References: <a@example.com> <b@example.com> <c@example.com>\r\n\r\n"
+        let data = Data(raw.utf8)
+
+        XCTAssertEqual(
+            client.parseReferencesHeader(from: data),
+            "<a@example.com> <b@example.com> <c@example.com>"
+        )
+    }
+
+    func testUnfoldsFoldedHeaderWithSpaceContinuation() {
+        let client = makeClient()
+        let raw = "References: <a@example.com>\r\n <b@example.com>\r\n <c@example.com>\r\n\r\n"
+        let data = Data(raw.utf8)
+
+        XCTAssertEqual(
+            client.parseReferencesHeader(from: data),
+            "<a@example.com> <b@example.com> <c@example.com>"
+        )
+    }
+
+    func testUnfoldsFoldedHeaderWithTabContinuation() {
+        let client = makeClient()
+        let raw = "References: <a@example.com>\r\n\t<b@example.com>\r\n\r\n"
+        let data = Data(raw.utf8)
+
+        XCTAssertEqual(
+            client.parseReferencesHeader(from: data),
+            "<a@example.com> <b@example.com>"
+        )
+    }
+
+    func testReturnsNilWhenHeaderMissing() {
+        let client = makeClient()
+        let raw = "Subject: Hello\r\n\r\n"
+        let data = Data(raw.utf8)
+
+        XCTAssertNil(client.parseReferencesHeader(from: data))
+    }
+
+    func testReturnsNilForEmptyValue() {
+        let client = makeClient()
+        let raw = "References: \r\n\r\n"
+        let data = Data(raw.utf8)
+
+        XCTAssertNil(client.parseReferencesHeader(from: data))
+    }
+
+    func testIgnoresOtherHeadersAndPicksReferences() {
+        let client = makeClient()
+        let raw = """
+        Subject: Re: Hello\r
+        References: <a@example.com> <b@example.com>\r
+        In-Reply-To: <b@example.com>\r
+        \r
+
+        """
+        let data = Data(raw.utf8)
+
+        XCTAssertEqual(
+            client.parseReferencesHeader(from: data),
+            "<a@example.com> <b@example.com>"
+        )
+    }
+
+    func testIsCaseInsensitiveOnHeaderName() {
+        let client = makeClient()
+        let raw = "REFERENCES: <a@example.com>\r\n\r\n"
+        let data = Data(raw.utf8)
+
+        XCTAssertEqual(client.parseReferencesHeader(from: data), "<a@example.com>")
+    }
+
+    func testFallsBackToISOLatin1ForNonUTF8Data() {
+        let client = makeClient()
+        // 0xE9 is é in ISO-8859-1 but not valid UTF-8 on its own.
+        var bytes: [UInt8] = Array("References: <\u{00E9}@example.com>\r\n\r\n".utf8)
+        // Replace the é UTF-8 bytes (0xC3 0xA9) with raw ISO-8859-1 0xE9.
+        if let c3Index = bytes.firstIndex(of: 0xC3), bytes.count > c3Index + 1, bytes[c3Index + 1] == 0xA9 {
+            bytes.remove(at: c3Index + 1)
+            bytes[c3Index] = 0xE9
+        }
+        let data = Data(bytes)
+
+        // UTF-8 decoding should fail, so this exercises the ISO-8859-1 fallback.
+        XCTAssertNil(String(data: data, encoding: .utf8))
+        XCTAssertEqual(client.parseReferencesHeader(from: data), "<é@example.com>")
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for the `References` header in `MessageSummary`, enabling proper email threading.

## Changes

- Added `references: String?` field to `MessageSummary`
- Parse `BODY[HEADER.FIELDS (REFERENCES)]` response in `parseMessageSummary`
- Added `parseReferencesHeader(from:)` helper to extract the value from raw header data

## Usage

```swift
let summary = try await client.fetchMessage(
    uid: uid,
    in: mailbox,
    items: [.uid, .flags, .internalDate, .rfc822Size, .envelope, 
            .bodyHeaderFields(fields: ["REFERENCES"], peek: true)]
)
// summary.references now contains the References header value
```

Fixes #8