### PR TITLE
Pin MimeParser by revision (closes #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Pin `MimeParser` dependency by revision (`0903ca7e`, current upstream master HEAD) instead of `branch: "master"` (#12)
+  - Allows downstream consumers to depend on SwiftIMAP via any stable version constraint (`exactVersion`, `upToNextMajor`, etc.)
+  - Preserves current MimeParser behaviour exactly (no source impact)
+
 ## [1.2.0] - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Pin `MimeParser` dependency by revision (`0903ca7e`, current upstream master HEAD) instead of `branch: "master"` (#12)
-  - Allows downstream consumers to depend on SwiftIMAP via any stable version constraint (`exactVersion`, `upToNextMajor`, etc.)
+- Pin `MimeParser` dependency by revision (`0903ca7e`) instead of `branch: "master"` (#12)
+  - Allows downstream consumers to depend on SwiftIMAP via any stable version constraint (for example, Exact Version or Up to Next Major)
   - Preserves current MimeParser behaviour exactly (no source impact)
 
 ## [1.2.0] - 2026-04-18

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -1,0 +1,18 @@
+# Learnings
+
+Lessons captured from past work to inform future development. Updated when merging PRs.
+
+---
+
+## SwiftPM dependencies
+
+- **Never pin dependencies by `branch:`**: SwiftPM rejects any graph where a stable-version consumer depends on a branch-pinned transitive dep ("required using a stable-version but ... depends on an unstable-version package"). Use `version:`, `from:`, `exact:`, or `revision:` for any dep we expect downstream apps to pin against. Branch pins break `exactVersion`, `upToNextMajor`, and every other stable constraint.
+- **Prefer `revision:` over `from:` when upstream master is ahead of the latest tag**: For dormant deps, `from: "<tag>"` silently regresses past any unreleased fixes on master. Check `gh api repos/<owner>/<repo>/compare/<latest-tag>...master --jq '{ahead_by, commits}'` before choosing. If commits are real bug fixes (not just CI plumbing), pin to a SHA on master.
+- **`Package.resolved` is gitignored for libraries in this repo**: Only apps commit `Package.resolved` (they dictate the resolved graph for the whole tree). Don't include it in PR diffs.
+- **`swift package resolve` is a no-op if the SHA already matches**: After flipping a manifest from `branch: "master"` to `revision: "<sha>"`, `Package.resolved` may retain the stale `"branch": "master"` hint alongside the revision. To force a clean rewrite: `swift package reset && rm -rf .build .swiftpm Package.resolved && swift package resolve`.
+- **Use precise SwiftPM terminology in docs and comments**: API spellings are `.exact("...")`, `.upToNextMajor(from:)`, etc. Xcode's UI labels are "Exact Version", "Up to Next Major". Avoid camel-cased pseudo-names like `exactVersion` or `upToNextMajor` — they imply a SwiftPM API that doesn't exist.
+
+## Evaluating dormant dependencies
+
+- **Audit fork health via the GitHub compare API, not the forks page**: `gh api repos/<owner>/<repo>/forks` lists 20+ forks for any modestly popular repo, almost all stale clones. To find a fork that has actually diverged: `gh api repos/<fork>/<repo>/compare/<upstream>:master...<fork>:master --jq '{ahead_by, behind_by}'`. Anything with `ahead_by: 0` is just a clone.
+- **Inventory open issues before forking**: A fork inherits responsibility for upstream's open issues. List them with `gh api 'repos/<owner>/<repo>/issues?state=open'` and the open PRs with `pulls?state=open` so the cost of ownership is explicit before committing.

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.3.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.3.0"),
-        // Pinned by revision (not branch) so SwiftPM consumers can resolve SwiftIMAP via `exactVersion`.
+        // Pinned by revision (not branch) so SwiftPM consumers can resolve SwiftIMAP using an exact version constraint.
         .package(url: "https://github.com/miximka/MimeParser.git", revision: "0903ca7e885cd39bfc559cda4eb78ce537edb1b9")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.3.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.3.0"),
-        .package(url: "https://github.com/miximka/MimeParser.git", branch: "master")
+        // Pinned by revision (not branch) so SwiftPM consumers can resolve SwiftIMAP via `exactVersion`.
+        .package(url: "https://github.com/miximka/MimeParser.git", revision: "0903ca7e885cd39bfc559cda4eb78ce537edb1b9")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

- Change MimeParser pin in `Package.swift` from `branch: "master"` → `revision: "0903ca7e..."` (current upstream master HEAD)
- Update CHANGELOG under `[Unreleased]`
- No source changes — this is a dependency-resolver fix only

## Why

SwiftPM rejects a graph where a stable-version consumer depends on a branch-pinned transitive dep, so downstream apps (e.g. MailTriage) can't pin SwiftIMAP via `exactVersion`, `upToNextMajor`, etc. They were forced to pin by commit SHA, which works but loses the human-readable version reference.

## Why `revision:` and not `from: "0.2.5"`

MimeParser publishes SemVer tags (latest `0.2.5`), but master is **8 commits ahead** of `0.2.5`, including the upstream PR #15 fix for "Header parser fails with empty headers". Pinning to `0.2.5` would silently drop that fix. Revision-pinning to current master HEAD preserves exact behaviour.

The `revision:` SHA gives consumers an audit point and SwiftPM treats it as a stable pin. Trade-off: consumers see a SHA in `Package.resolved` rather than a SemVer string. Acceptable given the alternative would regress parser correctness.

## Follow-up

Filed #13 to consider forking MimeParser to HokuNZ org — upstream is dormant (no pushes since 2023-06-09), and there are real correctness gaps (RFC 2047 encoded-words, 8-bit UTF-8) that we'll want to fix ourselves over time.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — all suites pass
- [x] `Package.resolved` (after full reset) shows clean `revision`-only state with no `branch` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)