### PR TITLE
Fix RFC 2047 decoder mismatching closer when Q-encoded text starts with =

### DIFF
--- a/Sources/SwiftIMAP/Utilities/RFC2047Decoder.swift
+++ b/Sources/SwiftIMAP/Utilities/RFC2047Decoder.swift
@@ -15,7 +15,6 @@ import Foundation
 /// - Malformed or unsupported encoded-words are passed through verbatim — the caller
 ///   never loses information they could otherwise have shown raw.
 public enum RFC2047 {
-
     public static func decode(_ input: String) -> String {
         let runs = parseRuns(input)
 

--- a/Sources/SwiftIMAP/Utilities/RFC2047Decoder.swift
+++ b/Sources/SwiftIMAP/Utilities/RFC2047Decoder.swift
@@ -28,16 +28,23 @@ public enum RFC2047 {
             if startRange.lowerBound > cursor {
                 runs.append(.literal(String(input[cursor..<startRange.lowerBound])))
             }
-            guard let endRange = input.range(of: "?=", range: startRange.upperBound..<input.endIndex) else {
+            // Skip past the two structural `?` separators (after charset, after encoding)
+            // before searching for the closing `?=`. RFC 2047 §2 forbids `?` inside the
+            // encoded-text, so `?=` after the second `?` is unambiguously the closer.
+            // Searching from startRange.upperBound directly false-matches Q-encoded text
+            // whose first byte is non-ASCII, where the separator after the encoding marker
+            // (`Q?`) meets the leading `=` of the first encoded byte (`=C3` etc.) and
+            // produces a `?=` substring inside the encoded-text.
+            guard let charsetEnd = input.range(of: "?", range: startRange.upperBound..<input.endIndex),
+                  let encodingEnd = input.range(of: "?", range: charsetEnd.upperBound..<input.endIndex),
+                  let endRange = input.range(of: "?=", range: encodingEnd.upperBound..<input.endIndex) else {
                 runs.append(.literal(String(input[startRange.lowerBound..<input.endIndex])))
                 break
             }
-            let encodedWord = input[startRange.upperBound..<endRange.lowerBound]
-            let parts = encodedWord.split(separator: "?", maxSplits: 2, omittingEmptySubsequences: false)
-            if parts.count == 3,
-               let decoded = decodeEncodedWord(charset: String(parts[0]),
-                                               encoding: String(parts[1]),
-                                               text: String(parts[2])) {
+            let charset = String(input[startRange.upperBound..<charsetEnd.lowerBound])
+            let encoding = String(input[charsetEnd.upperBound..<encodingEnd.lowerBound])
+            let text = String(input[encodingEnd.upperBound..<endRange.lowerBound])
+            if let decoded = decodeEncodedWord(charset: charset, encoding: encoding, text: text) {
                 runs.append(.decoded(decoded))
             } else {
                 runs.append(.literal(String(input[startRange.lowerBound..<endRange.upperBound])))

--- a/Sources/SwiftIMAP/Utilities/RFC2047Decoder.swift
+++ b/Sources/SwiftIMAP/Utilities/RFC2047Decoder.swift
@@ -17,6 +17,27 @@ import Foundation
 public enum RFC2047 {
 
     public static func decode(_ input: String) -> String {
+        let runs = parseRuns(input)
+
+        var output = ""
+        for (index, run) in runs.enumerated() {
+            switch run {
+            case .literal(let text):
+                if text.allSatisfy({ $0.isWhitespace }),
+                   index > 0, index < runs.count - 1,
+                   case .decoded = runs[index - 1],
+                   case .decoded = runs[index + 1] {
+                    continue
+                }
+                output += text
+            case .decoded(let text):
+                output += text
+            }
+        }
+        return output
+    }
+
+    private static func parseRuns(_ input: String) -> [Run] {
         var runs: [Run] = []
         var cursor = input.startIndex
 
@@ -51,23 +72,7 @@ public enum RFC2047 {
             }
             cursor = endRange.upperBound
         }
-
-        var output = ""
-        for (index, run) in runs.enumerated() {
-            switch run {
-            case .literal(let text):
-                if text.allSatisfy({ $0.isWhitespace }),
-                   index > 0, index < runs.count - 1,
-                   case .decoded = runs[index - 1],
-                   case .decoded = runs[index + 1] {
-                    continue
-                }
-                output += text
-            case .decoded(let text):
-                output += text
-            }
-        }
-        return output
+        return runs
     }
 
     // MARK: - Internals
@@ -99,9 +104,9 @@ public enum RFC2047 {
             if scalar == "_" {
                 bytes.append(0x20)
             } else if scalar == "=" {
-                guard let hi = iterator.next(),
-                      let lo = iterator.next(),
-                      let value = UInt8(String(hi) + String(lo), radix: 16) else {
+                guard let highNibble = iterator.next(),
+                      let lowNibble = iterator.next(),
+                      let value = UInt8(String(highNibble) + String(lowNibble), radix: 16) else {
                     return nil
                 }
                 bytes.append(value)

--- a/Tests/SwiftIMAPTests/RFC2047DecoderTests.swift
+++ b/Tests/SwiftIMAPTests/RFC2047DecoderTests.swift
@@ -46,6 +46,28 @@ final class RFC2047DecoderTests: XCTestCase {
         XCTAssertEqual(RFC2047.decode("=?iso-8859-1?q?caf=E9?="), "café")
     }
 
+    /// Q-encoded text whose first byte is non-ASCII begins with `=` (e.g. `=C3` for `Þ`).
+    /// The separator after the encoding marker (`Q?`) then directly precedes the `=`,
+    /// producing a `?=` substring inside the encoded-text. A naive forward search for the
+    /// closing `?=` from after `=?` matches that boundary instead of the real closer.
+    /// Regression for the v1.2.2 envelope-decoder gap that surfaced in MailTriage UAT.
+    func testQuotedPrintableLeadingNonAscii() {
+        XCTAssertEqual(
+            RFC2047.decode("=?UTF-8?Q?=C3=9E=C3=B3rd=C3=ADs_Halld=C3=B3ra?="),
+            "Þórdís Halldóra"
+        )
+    }
+
+    /// Same shape as above but with a 4-byte UTF-8 leading sequence (emoji) and a trailing
+    /// plain-ASCII literal. Exercises both the closer-ambiguity fix and the literal
+    /// continuation past the close.
+    func testQuotedPrintableLeadingEmojiWithTrailingPlain() {
+        XCTAssertEqual(
+            RFC2047.decode("=?utf-8?q?=F0=9F=8E=89?= Welcome aboard!"),
+            "🎉 Welcome aboard!"
+        )
+    }
+
     // MARK: - Mixed plain and encoded text
 
     func testEncodedWordWithSurroundingPlainText() {

--- a/Tests/SwiftIMAPTests/RFC2047DecoderTests.swift
+++ b/Tests/SwiftIMAPTests/RFC2047DecoderTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import SwiftIMAP
 
 final class RFC2047DecoderTests: XCTestCase {
-
     // MARK: - Plain text passes through unchanged
 
     func testPlainAsciiPassesThrough() {


### PR DESCRIPTION
Closes #17.

## Summary

When a Q-encoded encoded-word's first byte is non-ASCII (e.g. `=C3` for Þ, `=F0=9F=8E=89` for 🎉), the encoded-text begins with `=`. The previous decoder's forward search for the closing `?=` matched the boundary between the encoding marker (`Q?`) and the first encoded byte (`=...`) instead of the real closing delimiter, took the wrong substring, failed to split into 3 parts, and bailed out to literal pass-through.

Failing cases (full reproduction in the linked issue):
- `=?UTF-8?Q?=C3=9E=C3=B3rd=C3=ADs_Halld=C3=B3ra?=` → expected "Þórdís Halldóra", got the input unchanged
- `=?utf-8?q?=F0=9F=8E=89?= Welcome aboard!` → expected "🎉 Welcome aboard!", got the input unchanged

## Fix

Skip past the two structural `?` separators (after charset, after encoding) before searching for `?=`. Per RFC 2047 §2 the encoded-text MUST NOT contain `?`, so `?=` after the second `?` is unambiguously the closer.

## Tests

Added two regression tests:
- `testQuotedPrintableLeadingNonAscii` — Þórdís Q-encoded form
- `testQuotedPrintableLeadingEmojiWithTrailingPlain` — 🎉 + trailing plain ASCII

Full suite: 256 tests, 19 skipped, 0 failures (no other regressions).

## Test plan

- [x] `swift test --filter RFC2047DecoderTests` — 20 tests pass including the 2 new ones
- [x] `swift test` — full SwiftIMAP suite green
- [ ] Bump MailTriage's SwiftIMAP pin to a v1.2.3 release once this lands; re-run B3c-1 UAT against GreenMail and verify both Þórdís and 🎉 cards render decoded text

🤖 Generated with [Claude Code](https://claude.com/claude-code)