### PR TITLE
Expose MessageSummary.parseMimeContent as a static method (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `MessageSummary.parseMimeContent(from:)` is now available as a `static` method, so callers with raw RFC 822 bytes but no populated `MessageSummary` (e.g. an `.eml` fixture harness) can parse without synthesising a stub instance (#22). The existing instance method is retained as a thin wrapper; both reach the same code path.
+
 ## [1.2.4] - 2026-05-24
 
 ### Fixed

--- a/Sources/SwiftIMAP/Models/MessageSummary+MIME.swift
+++ b/Sources/SwiftIMAP/Models/MessageSummary+MIME.swift
@@ -2,18 +2,30 @@ import Foundation
 import MimeParser
 
 extension MessageSummary {
-    /// Parse MIME content from the given body data
-    public func parseMimeContent(from bodyData: Data) throws -> ParsedMimeMessage? {
+    /// Parse MIME content from raw RFC 822 body data.
+    ///
+    /// Reads no instance state, so callers with raw bytes but no populated
+    /// `MessageSummary` (e.g. an `.eml` fixture harness) can parse without
+    /// synthesising a stub instance.
+    public static func parseMimeContent(from bodyData: Data) throws -> ParsedMimeMessage? {
         // Convert Data to String for MimeParser
         guard let bodyString = String(data: bodyData, encoding: .utf8) else {
             throw IMAPError.parsingError("Failed to decode body data as UTF-8")
         }
-        
+
         // Parse the MIME content
         let parser = MimeParser()
         let mime = try parser.parse(bodyString)
-        
+
         return ParsedMimeMessage(from: mime)
+    }
+
+    /// Parse MIME content from the given body data.
+    ///
+    /// Convenience wrapper over ``parseMimeContent(from:)-swift.type.method`` for
+    /// callers that already hold a `MessageSummary`. No instance state is used.
+    public func parseMimeContent(from bodyData: Data) throws -> ParsedMimeMessage? {
+        try MessageSummary.parseMimeContent(from: bodyData)
     }
 }
 

--- a/Sources/SwiftIMAP/Models/MessageSummary+MIME.swift
+++ b/Sources/SwiftIMAP/Models/MessageSummary+MIME.swift
@@ -22,8 +22,8 @@ extension MessageSummary {
 
     /// Parse MIME content from the given body data.
     ///
-    /// Convenience wrapper over ``parseMimeContent(from:)-swift.type.method`` for
-    /// callers that already hold a `MessageSummary`. No instance state is used.
+    /// Convenience wrapper over the static `parseMimeContent(from:)` for callers
+    /// that already hold a `MessageSummary`. No instance state is used.
     public func parseMimeContent(from bodyData: Data) throws -> ParsedMimeMessage? {
         try MessageSummary.parseMimeContent(from: bodyData)
     }

--- a/Tests/SwiftIMAPTests/MIMEParsingTests.swift
+++ b/Tests/SwiftIMAPTests/MIMEParsingTests.swift
@@ -214,6 +214,44 @@ final class MIMEParsingTests: XCTestCase {
         XCTAssertNotNil(parsed?.firstPart(withContentType: "image/jpeg"))
     }
     
+    func testStaticParseMimeContentNeedsNoInstance() throws {
+        let messageData = """
+        From: sender@example.com
+        To: recipient@example.com
+        Subject: Static Parse
+        Content-Type: text/plain; charset=utf-8
+
+        Parsed without a MessageSummary instance.
+        """.data(using: .utf8)!
+
+        // No stub instance required.
+        let parsed = try MessageSummary.parseMimeContent(from: messageData)
+
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed?.plainTextContent, "Parsed without a MessageSummary instance.")
+    }
+
+    func testInstanceParseMimeContentMatchesStatic() throws {
+        let messageData = """
+        From: sender@example.com
+        Subject: Parity
+        Content-Type: text/plain; charset=utf-8
+
+        Body.
+        """.data(using: .utf8)!
+
+        let viaInstance = try createTestSummary().parseMimeContent(from: messageData)
+        let viaStatic = try MessageSummary.parseMimeContent(from: messageData)
+
+        XCTAssertEqual(viaInstance?.plainTextContent, viaStatic?.plainTextContent)
+        XCTAssertEqual(viaInstance?.parts.count, viaStatic?.parts.count)
+    }
+
+    func testStaticParseMimeContentThrowsOnInvalidUTF8() {
+        let invalid = Data([0xFF, 0xFE, 0xFD])
+        XCTAssertThrowsError(try MessageSummary.parseMimeContent(from: invalid))
+    }
+
     // Helper to create a test message summary
     private func createTestSummary() -> MessageSummary {
         MessageSummary(


### PR DESCRIPTION
## Summary

`MessageSummary.parseMimeContent(from:)` reads no instance state, but was instance-only — so consumers with raw RFC 822 bytes and no populated `MessageSummary` (e.g. MailTriage's `.eml` snapshot harness) had to synthesise a stub instance purely to dispatch the call. This exposes it as a `static` method and keeps the instance method as a thin wrapper.

Closes #22.

## Changes

- `static func MessageSummary.parseMimeContent(from:)` — the real implementation.
- Instance `parseMimeContent(from:)` now delegates to the static one (source-compatible; both hit the same path).

## Testing

- `swift test` → 269 tests, 0 failures (19 GreenMail/Docker skipped); no swiftlint errors.
- New tests: static parse needs no instance, instance/static parity, static throws on invalid UTF-8.

Additive and non-breaking; bundled into the in-flight v2.0 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)