### PR TITLE
Surface custom IMAP keywords on MessageSummary (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `MessageSummary.keywords: Set<String>` surfaces custom IMAP keywords the server reports that are not standard system flags — e.g. `$Forwarded`, `$Junk`/`$NotJunk`, or client-defined keywords like `@Triaged` (#23). Previously these were silently dropped because `flags` is a closed `Flag` enum. Purely additive: `flags` behaviour is unchanged and the new init parameter defaults to `[]`.
+
 ## [1.2.4] - 2026-05-24
 
 ### Fixed

--- a/Sources/SwiftIMAP/IMAPClient+Parsing.swift
+++ b/Sources/SwiftIMAP/IMAPClient+Parsing.swift
@@ -18,9 +18,8 @@ extension IMAPClient {
             case .uid(let uidValue):
                 uid = uidValue
             case .flags(let flagValues):
-                // Single pass: recognised system flags go to `flags`; anything else
-                // (e.g. $Forwarded, @Triaged) is a custom keyword the Flag enum would
-                // otherwise drop.
+                // A recognised system flag goes to `flags`; anything else
+                // (e.g. $Forwarded, @Triaged) is a custom keyword.
                 for value in flagValues {
                     if let flag = Flag(rawValue: value) {
                         flags.insert(flag)

--- a/Sources/SwiftIMAP/IMAPClient+Parsing.swift
+++ b/Sources/SwiftIMAP/IMAPClient+Parsing.swift
@@ -18,10 +18,16 @@ extension IMAPClient {
             case .uid(let uidValue):
                 uid = uidValue
             case .flags(let flagValues):
-                flags = Set(flagValues.compactMap { Flag(rawValue: $0) })
-                // Anything that is not a standard system flag is a custom keyword
-                // (e.g. $Forwarded, @Triaged) that the Flag enum would otherwise drop.
-                keywords = Set(flagValues.filter { Flag(rawValue: $0) == nil })
+                // Single pass: recognised system flags go to `flags`; anything else
+                // (e.g. $Forwarded, @Triaged) is a custom keyword the Flag enum would
+                // otherwise drop.
+                for value in flagValues {
+                    if let flag = Flag(rawValue: value) {
+                        flags.insert(flag)
+                    } else {
+                        keywords.insert(value)
+                    }
+                }
             case .internalDate(let date):
                 internalDate = date
             case .rfc822Size(let sizeValue):

--- a/Sources/SwiftIMAP/IMAPClient+Parsing.swift
+++ b/Sources/SwiftIMAP/IMAPClient+Parsing.swift
@@ -7,6 +7,7 @@ extension IMAPClient {
     ) throws -> MessageSummary {
         var uid: UID?
         var flags = Set<Flag>()
+        var keywords = Set<String>()
         var internalDate: Date?
         var size: UInt32?
         var envelope: Envelope?
@@ -18,6 +19,9 @@ extension IMAPClient {
                 uid = uidValue
             case .flags(let flagValues):
                 flags = Set(flagValues.compactMap { Flag(rawValue: $0) })
+                // Anything that is not a standard system flag is a custom keyword
+                // (e.g. $Forwarded, @Triaged) that the Flag enum would otherwise drop.
+                keywords = Set(flagValues.filter { Flag(rawValue: $0) == nil })
             case .internalDate(let date):
                 internalDate = date
             case .rfc822Size(let sizeValue):
@@ -44,6 +48,7 @@ extension IMAPClient {
             uid: uid,
             sequenceNumber: sequenceNumber,
             flags: flags,
+            keywords: keywords,
             internalDate: internalDate,
             size: size,
             envelope: envelope,

--- a/Sources/SwiftIMAP/Models/Message.swift
+++ b/Sources/SwiftIMAP/Models/Message.swift
@@ -6,7 +6,7 @@ public typealias MessageSequenceNumber = UInt32
 public struct MessageSummary: Sendable {
     public let uid: UID
     public let sequenceNumber: MessageSequenceNumber
-    /// Standard system flags (`\Seen`, `\Answered`, etc.).
+    /// The standard RFC 3501 system flags (see `Flag`).
     public let flags: Set<Flag>
     /// Custom IMAP keywords reported by the server, such as `$Forwarded`, `$Junk`,
     /// or `@Triaged`: any flag value that is not a standard system `Flag`.

--- a/Sources/SwiftIMAP/Models/Message.swift
+++ b/Sources/SwiftIMAP/Models/Message.swift
@@ -6,8 +6,7 @@ public typealias MessageSequenceNumber = UInt32
 public struct MessageSummary: Sendable {
     public let uid: UID
     public let sequenceNumber: MessageSequenceNumber
-    /// Standard system flags (`\Seen`, `\Answered`, etc.). Server keywords that
-    /// are not standard system flags are surfaced in ``keywords`` instead.
+    /// Standard system flags (`\Seen`, `\Answered`, etc.).
     public let flags: Set<Flag>
     /// Custom IMAP keywords the server reported that are not standard system
     /// flags — e.g. `$Forwarded`, `$Junk`/`$NotJunk`, or client-defined keywords

--- a/Sources/SwiftIMAP/Models/Message.swift
+++ b/Sources/SwiftIMAP/Models/Message.swift
@@ -6,7 +6,13 @@ public typealias MessageSequenceNumber = UInt32
 public struct MessageSummary: Sendable {
     public let uid: UID
     public let sequenceNumber: MessageSequenceNumber
+    /// Standard system flags (`\Seen`, `\Answered`, etc.). Server keywords that
+    /// are not standard system flags are surfaced in ``keywords`` instead.
     public let flags: Set<Flag>
+    /// Custom IMAP keywords the server reported that are not standard system
+    /// flags — e.g. `$Forwarded`, `$Junk`/`$NotJunk`, or client-defined keywords
+    /// such as `@Triaged`. Empty when the fetch reported no custom keywords.
+    public let keywords: Set<String>
     public let internalDate: Date
     public let size: UInt32
     public let envelope: Envelope?
@@ -19,6 +25,7 @@ public struct MessageSummary: Sendable {
         uid: UID,
         sequenceNumber: MessageSequenceNumber,
         flags: Set<Flag> = [],
+        keywords: Set<String> = [],
         internalDate: Date,
         size: UInt32,
         envelope: Envelope? = nil,
@@ -27,6 +34,7 @@ public struct MessageSummary: Sendable {
         self.uid = uid
         self.sequenceNumber = sequenceNumber
         self.flags = flags
+        self.keywords = keywords
         self.internalDate = internalDate
         self.size = size
         self.envelope = envelope

--- a/Sources/SwiftIMAP/Models/Message.swift
+++ b/Sources/SwiftIMAP/Models/Message.swift
@@ -8,9 +8,9 @@ public struct MessageSummary: Sendable {
     public let sequenceNumber: MessageSequenceNumber
     /// Standard system flags (`\Seen`, `\Answered`, etc.).
     public let flags: Set<Flag>
-    /// Custom IMAP keywords the server reported that are not standard system
-    /// flags — e.g. `$Forwarded`, `$Junk`/`$NotJunk`, or client-defined keywords
-    /// such as `@Triaged`. Empty when the fetch reported no custom keywords.
+    /// Custom IMAP keywords reported by the server, such as `$Forwarded`, `$Junk`,
+    /// or `@Triaged`: any flag value that is not a standard system `Flag`. Empty if
+    /// the fetch returned none.
     public let keywords: Set<String>
     public let internalDate: Date
     public let size: UInt32

--- a/Sources/SwiftIMAP/Models/Message.swift
+++ b/Sources/SwiftIMAP/Models/Message.swift
@@ -9,8 +9,7 @@ public struct MessageSummary: Sendable {
     /// Standard system flags (`\Seen`, `\Answered`, etc.).
     public let flags: Set<Flag>
     /// Custom IMAP keywords reported by the server, such as `$Forwarded`, `$Junk`,
-    /// or `@Triaged`: any flag value that is not a standard system `Flag`. Empty if
-    /// the fetch returned none.
+    /// or `@Triaged`: any flag value that is not a standard system `Flag`.
     public let keywords: Set<String>
     public let internalDate: Date
     public let size: UInt32

--- a/Tests/SwiftIMAPTests/IMAPClientMailboxFetchTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPClientMailboxFetchTests.swift
@@ -209,6 +209,58 @@ final class IMAPClientMailboxFetchTests: XCTestCase {
         await client.disconnect()
     }
 
+    func testFetchMessageSurfacesCustomKeywords() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        mockServer.setResponse(
+            for: "UID FETCH",
+            response: "* 1 FETCH (UID 1 FLAGS (\\Answered $Forwarded @Triaged) " +
+                      "INTERNALDATE \"17-Jul-1996 02:44:25 -0700\" RFC822.SIZE 4286)"
+        )
+
+        let client = makeClient()
+        try await client.connect()
+
+        let summary = try await client.fetchMessage(
+            uid: 1,
+            in: "INBOX",
+            items: [.uid, .flags, .internalDate, .rfc822Size]
+        )
+
+        XCTAssertNotNil(summary)
+        // Standard system flags stay in `flags`; custom keywords are surfaced separately.
+        XCTAssertEqual(summary?.flags, [.answered])
+        XCTAssertEqual(summary?.keywords, ["$Forwarded", "@Triaged"])
+
+        await client.disconnect()
+    }
+
+    func testFetchMessageWithoutCustomKeywordsHasEmptyKeywords() async throws {
+        mockServer.setResponse(for: "CAPABILITY", response: "* CAPABILITY IMAP4rev1 LOGIN")
+        mockServer.setResponse(for: "LOGIN", response: "OK LOGIN completed")
+        mockServer.setResponse(for: "SELECT", response: "OK [READ-WRITE] SELECT completed")
+        mockServer.setResponse(
+            for: "UID FETCH",
+            response: "* 1 FETCH (UID 1 FLAGS (\\Seen) " +
+                      "INTERNALDATE \"17-Jul-1996 02:44:25 -0700\" RFC822.SIZE 100)"
+        )
+
+        let client = makeClient()
+        try await client.connect()
+
+        let summary = try await client.fetchMessage(
+            uid: 1,
+            in: "INBOX",
+            items: [.uid, .flags, .internalDate, .rfc822Size]
+        )
+
+        XCTAssertEqual(summary?.flags, [.seen])
+        XCTAssertTrue(summary?.keywords.isEmpty ?? false)
+
+        await client.disconnect()
+    }
+
     func testListMessagesThrowsWhenDisconnected() async {
         let client = makeClient()
 


### PR DESCRIPTION
## Summary

`MessageSummary.flags` is a closed `Flag` enum (the six standard system flags), so the parser's `compactMap { Flag(rawValue:) }` **silently dropped every custom keyword**: `$Forwarded`, `$Junk`/`$NotJunk`, client-defined keywords like `@Triaged`, and any server-specific keyword. Consumers had no way to see them after parsing.

Adds a sibling `keywords: Set<String>` populated from the flag strings the `Flag` enum doesn't recognise.

Closes #23.

## Changes

- `MessageSummary.keywords: Set<String>` (new), with the init parameter defaulting to `[]`.
- Parser (`IMAPClient+Parsing.swift`): `flags` keeps the recognised system flags; `keywords` captures the rest.

## Backwards compatibility

Purely additive — `flags` behaviour is unchanged and existing call sites compile without modification (new init param defaults to `[]`). No breaking changes.

## Testing

- `swift test` → 268 tests, 0 failures (19 GreenMail/Docker skipped); no swiftlint errors.
- Round-trip test: a FETCH reporting `FLAGS (\Answered $Forwarded @Triaged)` parses to `flags == [.answered]` and `keywords == ["$Forwarded", "@Triaged"]`; a standard-only fetch yields empty `keywords`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)