### PR TITLE
Harden waitForGreeting handler lifecycle and resume race (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - **Breaking.** Dead `IMAPError` cases `mailboxNotFound`, `messageNotFound`, `quotaExceeded`, and `permissionDenied`, which had no producers (#27). The equivalent information is available uniformly via `IMAPServerResponse.code` and its semantic accessors.
 
+### Fixed
+- `ConnectionActor.waitForGreeting` no longer drops responses that arrive between the greeting and the persistent handler being installed (#26). The greeting handler is now a one-shot — it consumes the greeting batch and clears itself (inside the channel handler's lock, so no re-entrant deadlock), reverting the channel to buffering. The greeting closure's bare `resumedState` read was also replaced with a compare-and-exchange to remove a TOCTOU with the timeout task.
+
 ## [1.2.4] - 2026-05-24
 
 ### Fixed

--- a/Sources/SwiftIMAP/Networking/ConnectionActor.swift
+++ b/Sources/SwiftIMAP/Networking/ConnectionActor.swift
@@ -475,9 +475,10 @@ actor ConnectionActor {
     
     private func waitForGreeting() async throws -> IMAPResponse {
         return try await withCheckedThrowingContinuation { continuation in
+            // `resumedState` guarantees the continuation is resumed exactly once
+            // across the racing timeout task and the greeting handler.
             let resumedState = MutableState(value: false)
-            let greetingState = MutableState(value: false)
-            
+
             let greetingTimeout = ConnectionActor.nanoseconds(fromSeconds: configuration.connectionTimeout)
             let timeoutTask = Task {
                 try await Task.sleep(nanoseconds: greetingTimeout)
@@ -486,40 +487,37 @@ actor ConnectionActor {
                 }
             }
             
-            channelHandler?.setResponseHandler { [weak self] result in
-                guard !resumedState.value else { return }
-                
+            // One-shot: the handler is delivered the first response batch (the
+            // greeting) and then cleared, so any response arriving before the
+            // persistent handler is installed in connect() is buffered, not dropped.
+            channelHandler?.setResponseHandler({ [weak self] result in
                 switch result {
                 case .success(let responses):
-                    // Only handle the first set of responses as greeting
-                    if greetingState.compareAndExchange(expected: false, new: true) {
-                        if resumedState.compareAndExchange(expected: false, new: true) {
-                            timeoutTask.cancel()
-                            
-                            if let greeting = responses.first {
-                                // Process any CAPABILITY responses that came with the greeting
-                                Task { [weak self] in
-                                    for response in responses {
-                                        if case .untagged(.capability(let caps)) = response {
-                                            await self?.updateCapabilities(Set(caps))
-                                        } else if case .untagged(.status(let status)) = response {
-                                            await self?.updateCapabilitiesIfPresent(status)
-                                        }
-                                    }
+                    // CAS, not a bare read: the timeout task may have already won.
+                    guard resumedState.compareAndExchange(expected: false, new: true) else { return }
+                    timeoutTask.cancel()
+
+                    if let greeting = responses.first {
+                        // Process any CAPABILITY responses that came with the greeting
+                        Task { [weak self] in
+                            for response in responses {
+                                if case .untagged(.capability(let caps)) = response {
+                                    await self?.updateCapabilities(Set(caps))
+                                } else if case .untagged(.status(let status)) = response {
+                                    await self?.updateCapabilitiesIfPresent(status)
                                 }
-                                continuation.resume(returning: greeting)
-                            } else {
-                                continuation.resume(throwing: IMAPError.protocolError("No greeting received"))
                             }
                         }
+                        continuation.resume(returning: greeting)
+                    } else {
+                        continuation.resume(throwing: IMAPError.protocolError("No greeting received"))
                     }
                 case .failure(let error):
-                    if resumedState.compareAndExchange(expected: false, new: true) {
-                        timeoutTask.cancel()
-                        continuation.resume(throwing: error)
-                    }
+                    guard resumedState.compareAndExchange(expected: false, new: true) else { return }
+                    timeoutTask.cancel()
+                    continuation.resume(throwing: error)
                 }
-            }
+            }, oneShot: true)
         }
     }
     

--- a/Sources/SwiftIMAP/Networking/IMAPChannelHandler.swift
+++ b/Sources/SwiftIMAP/Networking/IMAPChannelHandler.swift
@@ -14,6 +14,7 @@ final class IMAPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
     private let parser = IMAPParser()
     private let lock = NIOLock()
     private var _responseHandler: ((Result<[IMAPResponse], Error>) -> Void)?
+    private var _oneShot = false
     private var _pendingResults: [Result<[IMAPResponse], Error>] = []
     private let logger: Logger
 
@@ -58,14 +59,28 @@ final class IMAPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
     // on two threads at once. Handlers must therefore not synchronously re-enter
     // `setResponseHandler`/`dispatch` (NIOLock is non-reentrant); the connect
     // path's handlers only spawn a Task / resume a continuation, so they don't.
-    func setResponseHandler(_ handler: ((Result<[IMAPResponse], Error>) -> Void)?) {
+    //
+    // A `oneShot` handler is delivered exactly one result batch and then cleared
+    // (under the same lock, without re-entry) so the channel reverts to buffering.
+    // The greeting handler uses this so any response arriving between the greeting
+    // and the persistent handler being installed is buffered rather than dropped
+    // by a stale greeting closure (#26).
+    func setResponseHandler(_ handler: ((Result<[IMAPResponse], Error>) -> Void)?, oneShot: Bool = false) {
         lock.withLock {
             _responseHandler = handler
-            guard let handler else { return }
-            for result in _pendingResults {
-                handler(result)
+            _oneShot = oneShot
+            guard _responseHandler != nil else { return }
+            // Drain buffered results. A one-shot handler consumes only the first
+            // batch and then clears itself, leaving the remainder buffered for the
+            // next handler.
+            while !_pendingResults.isEmpty, let handler = _responseHandler {
+                handler(_pendingResults.removeFirst())
+                if _oneShot {
+                    _responseHandler = nil
+                    _oneShot = false
+                    break
+                }
             }
-            _pendingResults.removeAll()
         }
     }
 
@@ -73,6 +88,10 @@ final class IMAPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
         lock.withLock {
             if let handler = _responseHandler {
                 handler(result)
+                if _oneShot {
+                    _responseHandler = nil
+                    _oneShot = false
+                }
             } else {
                 _pendingResults.append(result)
             }

--- a/Sources/SwiftIMAP/Networking/IMAPChannelHandler.swift
+++ b/Sources/SwiftIMAP/Networking/IMAPChannelHandler.swift
@@ -56,15 +56,17 @@ final class IMAPChannelHandler: ChannelInboundHandler, @unchecked Sendable {
 
     // The handler is invoked while `lock` is held so that a buffer drain and a
     // concurrent live `dispatch` cannot deliver out of order or run the handler
-    // on two threads at once. Handlers must therefore not synchronously re-enter
-    // `setResponseHandler`/`dispatch` (NIOLock is non-reentrant); the connect
-    // path's handlers only spawn a Task / resume a continuation, so they don't.
+    // on two threads at once. Handlers must therefore NOT synchronously re-enter
+    // `setResponseHandler`/`dispatch` (NIOLock is non-reentrant) — a handler may
+    // only spawn a Task or resume a continuation. Both current callers (the
+    // greeting and persistent handlers in `connect()`) honour this.
     //
-    // A `oneShot` handler is delivered exactly one result batch and then cleared
-    // (under the same lock, without re-entry) so the channel reverts to buffering.
-    // The greeting handler uses this so any response arriving between the greeting
-    // and the persistent handler being installed is buffered rather than dropped
-    // by a stale greeting closure (#26).
+    // A `oneShot` handler is delivered exactly one result batch — one
+    // `Result<[IMAPResponse], Error>`, i.e. all responses parsed from a single
+    // read — and is then cleared (under the same lock, without re-entry) so the
+    // channel reverts to buffering. The greeting handler uses this so any response
+    // arriving between the greeting and the persistent handler being installed is
+    // buffered rather than dropped by a stale greeting closure (#26).
     func setResponseHandler(_ handler: ((Result<[IMAPResponse], Error>) -> Void)?, oneShot: Bool = false) {
         lock.withLock {
             _responseHandler = handler

--- a/Tests/SwiftIMAPTests/IMAPChannelHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPChannelHandlerTests.swift
@@ -76,6 +76,61 @@ final class IMAPChannelHandlerTests: XCTestCase {
         XCTAssertEqual(secondHandlerCount, 0, "Second handler should not see the already-drained buffer")
     }
 
+    private func writeLine(_ line: String, into channel: EmbeddedChannel) throws {
+        var buffer = channel.allocator.buffer(capacity: 64)
+        buffer.writeString(line + "\r\n")
+        try channel.writeInbound(buffer)
+    }
+
+    /// A one-shot handler receives the first live batch and is then cleared, so
+    /// subsequent responses buffer for the next handler rather than hitting the
+    /// stale one-shot closure (#26).
+    func testOneShotHandlerConsumesFirstBatchThenBuffers() throws {
+        let handler = makeHandler()
+        let channel = EmbeddedChannel(handler: handler)
+        defer { try? channel.finish() }
+
+        var oneShotCount = 0
+        handler.setResponseHandler({ result in
+            if case .success = result { oneShotCount += 1 }
+        }, oneShot: true)
+
+        try writeLine("* OK greeting", into: channel)
+        try writeLine("* BYE later", into: channel)
+
+        XCTAssertEqual(oneShotCount, 1, "One-shot handler must see only the first batch")
+
+        var nextCount = 0
+        handler.setResponseHandler { result in
+            if case .success = result { nextCount += 1 }
+        }
+        XCTAssertEqual(nextCount, 1, "Response after the one-shot fired must buffer for the next handler")
+    }
+
+    /// A one-shot handler installed after responses were buffered consumes only
+    /// the first buffered batch; the rest stays buffered for the next handler.
+    func testOneShotHandlerDrainsOnlyFirstBufferedBatch() throws {
+        let handler = makeHandler()
+        let channel = EmbeddedChannel(handler: handler)
+        defer { try? channel.finish() }
+
+        // Two batches buffered before any handler is installed.
+        try writeLine("* OK greeting", into: channel)
+        try writeLine("* BYE later", into: channel)
+
+        var oneShotCount = 0
+        handler.setResponseHandler({ result in
+            if case .success = result { oneShotCount += 1 }
+        }, oneShot: true)
+        XCTAssertEqual(oneShotCount, 1, "One-shot must drain only the first buffered batch")
+
+        var nextCount = 0
+        handler.setResponseHandler { result in
+            if case .success = result { nextCount += 1 }
+        }
+        XCTAssertEqual(nextCount, 1, "Remaining buffered batch must go to the next handler")
+    }
+
     /// Setting the handler to nil clears it without losing future responses.
     func testClearingHandlerThenSettingNewOneBuffersInBetween() throws {
         let handler = makeHandler()

--- a/Tests/SwiftIMAPTests/IMAPChannelHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPChannelHandlerTests.swift
@@ -107,6 +107,35 @@ final class IMAPChannelHandlerTests: XCTestCase {
         XCTAssertEqual(nextCount, 1, "Response after the one-shot fired must buffer for the next handler")
     }
 
+    /// A one-shot handler is cleared after a `.failure` batch too (not just
+    /// `.success`), so the next handler still drains a later buffered batch
+    /// rather than the failure being delivered twice or the one-shot lingering.
+    func testOneShotHandlerClearsAfterFailureBatch() throws {
+        let handler = makeHandler()
+        let channel = EmbeddedChannel(handler: handler)
+        defer { try? channel.finish() }
+
+        var oneShotResults: [Result<[IMAPResponse], Error>] = []
+        handler.setResponseHandler({ result in oneShotResults.append(result) }, oneShot: true)
+
+        // A malformed line makes the parser throw, which `channelRead` dispatches
+        // as a `.failure` batch.
+        try writeLine("A1 BOGUS", into: channel)
+        XCTAssertEqual(oneShotResults.count, 1)
+        if case .success = oneShotResults.first {
+            XCTFail("Expected a .failure batch")
+        }
+
+        // One-shot must have cleared, so a subsequent valid batch buffers for the
+        // next handler instead of hitting the spent one-shot closure.
+        try writeLine("* OK ready", into: channel)
+        var nextCount = 0
+        handler.setResponseHandler { result in
+            if case .success = result { nextCount += 1 }
+        }
+        XCTAssertEqual(nextCount, 1, "Batch after a one-shot failure must buffer for the next handler")
+    }
+
     /// A one-shot handler installed after responses were buffered consumes only
     /// the first buffered batch; the rest stays buffered for the next handler.
     func testOneShotHandlerDrainsOnlyFirstBufferedBatch() throws {


### PR DESCRIPTION
## Summary

Tightens two latent fragilities in `ConnectionActor.connect()` / `waitForGreeting()`, found during the review of #25 and confirmed still present after #28.

Closes #26.

> **Base branch:** this targets `version/v2.0` (#28), not `main`, because it builds directly on the greeting/timeout changes in that PR. Merge after #28.

## Changes

1. **TOCTOU on resume (fix #1).** The greeting closure read `resumedState.value` bare before its compare-and-exchange — racy against the timeout task. Replaced with a single CAS, so the continuation is resumed exactly once with no pre-read.

2. **Dropped responses in the handover window (fix #2).** The greeting closure stayed installed after resuming, so any response arriving before `connect()` installed the persistent handler hit the stale closure (which ignored it) and was dropped rather than buffered (post-#25). The greeting handler is now a **one-shot**: `IMAPChannelHandler` delivers it the first batch then clears it.

### Why not the issue's literal suggestion

The issue suggested calling `setResponseHandler(nil)` from inside the greeting closure. That would **deadlock**: the handler runs while the channel handler's `NIOLock` is held, and the lock is non-reentrant. Instead, the one-shot clears `_responseHandler` directly inside the same locked dispatch — no re-entry.

## Testing

- `swift test` → 282 tests, 0 failures (19 GreenMail/Docker skipped); no swiftlint errors.
- New `IMAPChannelHandler` tests: one-shot consumes the first live batch then buffers the rest; one-shot installed over a buffer drains only the first batch and leaves the remainder for the next handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)