### PR TITLE
Add v2.0 external API review and decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,7 @@ Package.pins
 Package.resolved
 *.xcodeproj
 
-# Generated documentation (but keep docs/images for static assets)
-docs/*
-!docs/images/
+# Generated documentation
 .docc-build/
 
 # Temporary files

--- a/docs/api-review-v2.md
+++ b/docs/api-review-v2.md
@@ -490,3 +490,39 @@ Independent review accepted; loose ends resolved as follows.
 Items 2 and 3 of the draft migration guide shrink accordingly (wire types stay
 public; only `searchMessagesComplex`, `listMessages`, and `fetchMessageBySequence`
 are removed; `appendMessage` keeps its current signature).
+
+---
+
+## Decisions, second pass (2026-06-06, after PRs #41-#45)
+
+Scope revisited once the first wave was implemented and reviewed.
+
+### Added to v2.0
+
+- **C2 (read side only)** — `fetchMessageBody` gets the full retry/reconnect
+  wrapper like `fetchMessage`. Writes remain out of scope (sent-vs-not-sent
+  ambiguity stands).
+- **C3** — bounded `LOGOUT` in `disconnect()` instead of waiting out
+  `commandTimeout` on a dead channel.
+- **D4** — batch the N+1 sequential fetch in `searchMessages` into a single
+  `UID FETCH` with a sequence set.
+- **E1** — `MessageSummary.referenceIDs: [String]` (parsed message-IDs;
+  raw `references` retained).
+- **E2** — optional `expectedUIDValidity:` parameter on write operations,
+  enforced at SELECT time.
+- **G1** — add missing `Equatable`/`Hashable` conformances now.
+- **B3 note carried into release prep**: with `IMAPCommand.Command` staying
+  public, reword the CHANGELOG `label` entry so `IMAPServerResponse.commandName`
+  is presented as the supported way to learn which command failed, with `label`
+  as the underlying plumbing.
+
+### Confirmed deferred
+
+- **B1-B3** — wire-layer internalisation stays out (API-positioning decision,
+  per the independent review).
+- **C2 (writes)** — out of scope as before.
+- **E3** — APPENDUID return on `appendMessage`: tracked as an issue rather than
+  implemented in v2.0 (depends on correct APPENDUID response-code parsing and a
+  decision on the no-UIDPLUS return shape).
+- **G3** — NIOSSL wrapping: tracked as an issue, scoped to the v3.0 / Swift 6
+  pass.

--- a/docs/api-review-v2.md
+++ b/docs/api-review-v2.md
@@ -12,10 +12,11 @@ Date: 2026-06-06. Branch under review: `version/v2.0` (post-#27 error-handling w
 - Clean breaks, no deprecation shims.
 - The repo is public, so the surface should also be coherent and well documented for
   unknown future consumers, with a migration guide.
-- Enum policy: library enums may gain new cases in **minor** releases. Consumers must
-  always include a `default` (or `@unknown default` is not available for source
-  packages, so a plain `default`) when switching over library enums. Documented in the
-  README as part of this release.
+- Enum policy: library enums may gain new cases in **minor** releases. This is
+  published guidance, not something the library can enforce: Swift source packages are
+  non-resilient, so consumers *can* switch exhaustively and `@unknown default` is
+  unavailable to them. The README advises a plain `default` arm when switching over
+  library enums; consumers who switch exhaustively accept source breakage on minors.
 - Swift 6 strict concurrency is out of scope (parked for v3.0).
 - Internal-detail exposure is bounded by what MailTriage demonstrably needs or has
   worked around.
@@ -104,10 +105,13 @@ as `.commandFailed(response)` like any other command. Consumers will naturally
 pattern-match `.authenticationFailed` for auth UX (MailTriage's classifier does
 exactly this) and silently miss the actual server rejection.
 
-Recommendation: reshape to `authenticationFailed(IMAPServerResponse?)` and have the
-auth path map a `NO`/`BAD` completion of LOGIN/AUTHENTICATE into it (response carried;
-`nil` for local failures, or keep a message string alongside). The semantic accessor
-`isAuthenticationFailure` remains useful for rejections outside the auth flow.
+Recommendation (reworked after independent review): reshape to
+`authenticationFailed(String, response: IMAPServerResponse?)`. The `String` keeps the
+existing local-failure detail (encoding failures, nil SASL handler response, with
+`response: nil`); the auth path maps a `NO`/`BAD` completion of LOGIN/AUTHENTICATE
+into the same case with the server response carried. Auth UX consumers match one
+case and lose nothing. The semantic accessor `isAuthenticationFailure` remains useful
+for rejections outside the auth flow.
 MailTriage cost: inside the switch arm it already has.
 
 ### B. Over-exposed wire layer
@@ -350,13 +354,139 @@ For the README / release notes once changes land:
 5. `connect()` is now idempotent; `appendMessage` returns the new UID where the
    server supports UIDPLUS
 
-## Suggested implementation order
+## Implementation order (revised per Decisions below)
 
 1. A1-A5 (error surface) — one PR, extends #27, includes RetryHandler dead branches
-2. B1-B4 + G2 (internalise wire layer, MimeBody, Sendable) — one PR
-3. C1-C3 + A4 tests (connection lifecycle/resilience) — one PR, the riskiest; needs
-   GreenMail coverage
-4. D1-D5 (footguns and round-trips) — one or two PRs
-5. E1-E3 (additive workaround knockouts) — one PR
-6. F1-F2 (surface trim) — one PR, mostly deletions + README/Examples updates
-7. Migration guide + CHANGELOG consolidation + enum-policy README note — final PR
+2. D1-D3 + D5 (footguns and the per-move CAPABILITY round trip) — one PR
+3. C1 (idempotent `connect()`) — own PR, needs GreenMail coverage
+4. B4 + G2 (MimeBody internalisation, Sendable) — one PR
+5. F2 + `searchMessagesComplex` removal (surface trim) — one PR, deletions +
+   README/Examples updates
+6. Migration guide + CHANGELOG consolidation + enum-policy README note — final PR
+
+---
+
+## Independent review notes
+
+The review is mostly sound, but it overstates the urgency of several items. I would
+separate "must fix before v2.0" from "nice cleanup while the surface is already
+moving."
+
+### Poorly considered / too broad
+
+1. **B1-B3: internalising the whole wire layer**
+
+   The argument is MailTriage-centric: "unused by known consumers". For a public IMAP
+   package, `IMAPParser`, `IMAPEncoder`, `IMAPResponse`, and `IMAPCommand.Command`
+   may plausibly be useful for diagnostics, testing servers, proxies, or advanced
+   clients. Removing them from public API is defensible, but the doc treats it as
+   obvious. I would either keep them public but mark them as low-level/unstable in
+   docs, or move this to a separate deliberate API-positioning decision.
+
+2. **F1: removing convenience search wrappers**
+
+   This feels unnecessary. The wrappers in `IMAPClient+Search.swift` are small and
+   user-friendly. Removing them saves little maintenance and makes the API less
+   approachable. `searchMessagesComplex` is uglier and could go, but deleting all
+   convenience methods because MailTriage does not use them is too aggressive.
+
+3. **E2: UIDVALIDITY guard on write operations**
+
+   The goal is valid, but the "atomically and for free" claim is overstated. The
+   library SELECTs before writes today, yes, but adding `expectedUIDValidity` to many
+   write APIs expands the API and requires careful semantics around selected mailbox
+   state, reconnects, and servers that omit or behave oddly. This is useful, not
+   obviously v2-blocking.
+
+4. **C2: uniform retry/reconnect across writes**
+
+   The doc correctly notes ambiguity for writes, but the proposed "provably
+   pre-execution" split is non-trivial. Today `sendCommandInternal` registers pending
+   commands before write completion, and write failure handling is low-level. Building
+   a correct sent/not-sent retry contract is worthwhile, but risky enough that I would
+   not bundle it into an API cleanup unless there are failing production cases.
+
+5. **E3: `appendMessage` returning UID**
+
+   Additive and useful, but not necessary for v2. It depends on parsing APPENDUID
+   response codes correctly and deciding what to return when UIDPLUS is absent. Fine
+   for v2.x. Not a release blocker.
+
+6. **G1: add `Equatable`/`Hashable` "for tidiness"**
+
+   Harmless, but explicitly not urgent. Additive conformances can land later. I would
+   not spend release focus here unless tests need them.
+
+7. **A5: `authenticationFailed(IMAPServerResponse?)` shape**
+
+   The problem is real: LOGIN/AUTHENTICATE rejection currently emerges as
+   `commandFailed`. But changing local auth failures from a useful `String` to `nil`
+   risks losing detail. Better shape would be something like
+   `authenticationFailed(String, response: IMAPServerResponse?)`, or keep
+   `commandFailed` plus add an `isAuthenticationFailure` classifier. The suggested
+   shape is under-specified.
+
+### Strong suggestions I agree with
+
+- **D1 is the most important fix.** Falling back from targeted `UID EXPUNGE` to
+  whole-mailbox `EXPUNGE` is a real data-loss footgun.
+- **D2 should follow D1.** `deleteMessages` loops per UID and then calls
+  whole-mailbox expunge.
+- **D3 is valid.** `SequenceSet.set([])` returning UID `0` is a bad public trap.
+- **A1-A4 are reasonable.** The error cleanup and reconnect classification are
+  coherent, especially since `requiresReconnection` excludes `.disconnected` today.
+- **D5 is cheap and worthwhile.** `moveMessage(s)` paying a network `CAPABILITY` each
+  time is unnecessary after capabilities are cached.
+- **B4 is reasonable.** Publicly exposing `MimeBody` leaks a dependency type.
+
+### Suggested priority
+
+For v2.0: do A1-A4, D1-D3, D5, B4, maybe C1.
+
+Defer: B1-B3, C2, E2, E3, G1, most of F1.
+
+Rework before accepting: A5 and the enum-policy claim that consumers "must" include
+default arms. That is guidance, not something the library can enforce cleanly for
+Swift package enums.
+
+---
+
+## Decisions (2026-06-06, post-review)
+
+Independent review accepted; loose ends resolved as follows.
+
+### In scope for v2.0
+
+- **A1–A4** — error-case cleanup and reconnect classification (with regression test)
+- **A5** — reworked shape: `authenticationFailed(String, response: IMAPServerResponse?)`
+  (recommendation above updated to match)
+- **B4 + G2** — internalise `MimePart.body`, then make `ParsedMimeMessage`/`MimePart`
+  `Sendable` (G2 becomes trivial once B4 lands; bundled in one PR)
+- **C1** — idempotent `connect()`: cheapest part of the resilience story, direct
+  driver of the MailTriage rebuild workaround, and unlike C2 carries no
+  write-idempotency risk
+- **D1–D3, D5** — footguns and the per-move CAPABILITY round trip
+- **F1 (partial)** — remove `searchMessagesComplex` only; the simple wrappers stay
+- **F2** — remove deprecated `listMessages` and `fetchMessageBySequence` (a major is
+  the only clean removal point; the latter gets no deprecation grace because it has
+  the same instability problem and no known consumer)
+- Migration guide, CHANGELOG consolidation, enum-policy guidance in README (reworded
+  per review: guidance, not enforcement)
+
+### Deferred
+
+- **B1–B3** (wire-layer internalisation) — needs a deliberate API-positioning
+  decision for the public package, not a side effect of this review
+- **C2** (uniform write retry) — correct sent/not-sent contract is non-trivial;
+  revisit if production failures demand it
+- **C3** (bounded LOGOUT in `disconnect()`), **D4** (batch fetch in
+  `searchMessages`), **E1** (`referenceIDs`), **E2** (UIDVALIDITY guard),
+  **E3** (APPENDUID return) — all non-breaking; no major required, land in v2.x
+  as needed
+- **G1** (Equatable/Hashable), **G3** (NIOSSL wrapping), rest of **F1** — v2.x/v3.0
+
+### Migration-guide impact
+
+Items 2 and 3 of the draft migration guide shrink accordingly (wire types stay
+public; only `searchMessagesComplex`, `listMessages`, and `fetchMessageBySequence`
+are removed; `appendMessage` keeps its current signature).

--- a/docs/api-review-v2.md
+++ b/docs/api-review-v2.md
@@ -1,0 +1,362 @@
+# SwiftIMAP v2.0 external API review
+
+Date: 2026-06-06. Branch under review: `version/v2.0` (post-#27 error-handling work).
+
+## Brief
+
+- v2.0 already contains breaking changes (`IMAPError` reshape, #27), so MailTriage must
+  adapt regardless. This major is the cheap window for any other breaking fixes; the next
+  window is v3.0.
+- Every candidate break is weighed against MailTriage's **measured** migration cost
+  (its source was audited for this review), not hypothetical cost.
+- Clean breaks, no deprecation shims.
+- The repo is public, so the surface should also be coherent and well documented for
+  unknown future consumers, with a migration guide.
+- Enum policy: library enums may gain new cases in **minor** releases. Consumers must
+  always include a `default` (or `@unknown default` is not available for source
+  packages, so a plain `default`) when switching over library enums. Documented in the
+  README as part of this release.
+- Swift 6 strict concurrency is out of scope (parked for v3.0).
+- Internal-detail exposure is bounded by what MailTriage demonstrably needs or has
+  worked around.
+
+## Method
+
+- Full read of the public surface (~47 public types, ~232 public members) on
+  `version/v2.0`.
+- Producer audit: every `IMAPError` case traced to its `throw` sites.
+- Consumer audit: every SwiftIMAP symbol referenced by MailTriage, including its error
+  handling sites and the workarounds it carries for library limitations.
+- In-repo consumers checked: `IMAPCLITool` and `Examples/` use only the high-level
+  client API; tests use `@testable import` throughout.
+
+## Measured MailTriage surface
+
+Load-bearing API (everything MailTriage production code touches):
+
+- `IMAPClient`: `init`, `connect`, `disconnect`, `listMailboxes`, `searchMessages`,
+  `fetchMessageBody`, `storeFlags` (3 overloads), `moveMessages`, `appendMessage`,
+  `mailboxStatus`
+- `IMAPConfiguration` (+ `TLSMode`, `AuthMethod.login`), `RetryConfiguration.default`
+- `IMAPCommand.SearchCriteria` (`.since`, `.unseen`, `.unkeyword`, `.header`),
+  `IMAPCommand.FetchItem`, `IMAPCommand.StatusItem.uidValidity`,
+  `IMAPCommand.StoreFlags.Action.add`
+- `MessageSummary` (`uid`, `flags`, `keywords`, `envelope`, `internalDate`,
+  `references`), `Envelope`, `Address`, `Flag`, `Mailbox` (+ `Attribute`),
+  `MailboxStatus.uidValidity`, `parseMimeContent`/`ParsedMimeMessage`/`MimePart`
+  (decoded accessors only)
+- `IMAPError`: exhaustive switch in `IMAPService.swift` (error classification) and
+  case extraction in `IMAPMailAccount+WriteErrors.swift` (Bugsnag metadata)
+
+Everything else on the public surface is unused by MailTriage and can be reshaped
+freely. Total forced MailTriage migration for all changes proposed below: **the two
+error-handling files it must already touch for #27**.
+
+---
+
+## Findings
+
+### A. Error surface (completes the #27 cleanup)
+
+#### A1 ⛔️ Remove dead case `IMAPError.serverError`
+
+No producers anywhere in the library (verified by grep over all `throw` sites). Same
+situation as the four cases removed in #27. It also has dead string-matching branches
+in `RetryHandler.isRetryableError` and `requiresReconnection`
+(`RetryHandler.swift:141-143`, `212-215`) that should go with it.
+MailTriage cost: one switch arm deleted in code it is already editing.
+
+#### A2 ⛔️ Remove case `IMAPError.connectionError`
+
+Sole producer is the `lastError ?? IMAPError.connectionError(...)` fallback in
+`RetryHandler.swift:48` and `:108`, which is unreachable (`maxAttempts >= 1` is
+enforced at construction, so `lastError` is always set when the loop exits). Replace
+the fallback with `connectionFailed` (or a precondition) and delete the case. It
+currently duplicates `connectionFailed` and forces consumers to handle both.
+MailTriage cost: one switch arm deleted.
+
+#### A3 ⛔️ Fold `IMAPError.disconnected` into `connectionClosed(nil)`
+
+`.disconnected` means "connection is gone, server said nothing";
+`.connectionClosed(IMAPServerResponse?)` already models "connection is gone" with an
+*optional* server response. Two cases for the same consumer decision is a trap: every
+caller must remember to handle both. Producers (`IMAPChannelHandler.swift:54`,
+`ConnectionActor.swift:202,331,568`) become `connectionClosed(nil)`.
+MailTriage cost: one switch arm deleted (it already maps both to the same category).
+
+#### A4 ⛔️ Reconnect classification must treat abrupt loss as reconnectable
+
+`requiresReconnection` (`RetryHandler.swift:208-219`) does not include
+`.disconnected`, yet an abrupt TCP drop fails pending commands with exactly
+`.disconnected` (`IMAPChannelHandler.swift:54`). Result: a dropped connection
+mid-session is neither retried nor reconnected; the operation just fails. This is a
+root cause of MailTriage's "reset the Core actor and rebuild the client on any error"
+workaround. A3 fixes this mechanically (`connectionClosed` is already classified as
+reconnectable), but it needs its own regression test. Internal behaviour change, no
+API impact.
+
+#### A5 ⛔️ Server-rejected authentication should surface as `authenticationFailed`
+
+`.authenticationFailed(String)` is currently thrown only for *local* failures
+(credential encoding, nil SASL handler response — `IMAPClient+Connection.swift:138,153`,
+`ConnectionActor.swift:632`). A real server rejection of LOGIN/AUTHENTICATE surfaces
+as `.commandFailed(response)` like any other command. Consumers will naturally
+pattern-match `.authenticationFailed` for auth UX (MailTriage's classifier does
+exactly this) and silently miss the actual server rejection.
+
+Recommendation: reshape to `authenticationFailed(IMAPServerResponse?)` and have the
+auth path map a `NO`/`BAD` completion of LOGIN/AUTHENTICATE into it (response carried;
+`nil` for local failures, or keep a message string alongside). The semantic accessor
+`isAuthenticationFailure` remains useful for rejections outside the auth flow.
+MailTriage cost: inside the switch arm it already has.
+
+### B. Over-exposed wire layer
+
+In-repo evidence: no consumer (MailTriage, CLI tool, Examples) touches any of these;
+tests reach them via `@testable`.
+
+#### B1 ⛔️ Internalise `IMAPParser` and `IMAPEncoder`
+
+Wire-format codecs with `public` classes and methods. Internalising removes the
+implied stability contract for the parser's incremental-feed design, which we may
+want to change freely.
+
+#### B2 ⛔️ Internalise the `IMAPResponse` hierarchy; hoist `ResponseCode`
+
+`IMAPResponse` and its nested types (`UntaggedResponse`, `FetchAttribute`,
+`EnvelopeData`, `AddressData`, `BodyStructureData`, `DispositionData`, ...) are ~45
+public declarations of raw wire format, including `raw*: Data` fields. Nothing public
+returns them. The single public dependency is `IMAPServerResponse.code:
+IMAPResponse.ResponseCode`.
+
+Recommendation: hoist `ResponseCode` to a top-level `public enum IMAPResponseCode`
+(internal `typealias` keeps library code unchanged), make everything else internal.
+MailTriage cost: nil (it reads `code` via the semantic accessors and `codeName`).
+
+#### B3 ⛔️ Internalise `IMAPCommand`'s wire half, keep the criteria namespace
+
+`IMAPCommand.Command` (which includes `.login(username:password:)`),
+`UIDCommand`, `tag`, `command`, and `init(tag:command:)` are wire-level and unused by
+consumers. `IMAPCommand.SearchCriteria`, `FetchItem`, `StatusItem`, `StoreFlags`, and
+`SequenceSet` are genuine client API used by MailTriage, and must keep their nesting
+(so `IMAPCommand.SearchCriteria` spellings keep compiling).
+
+Note: the unreleased CHANGELOG advertises `IMAPCommand.Command.label` as public; that
+entry should be revised (the public face of "which command failed" is
+`IMAPServerResponse.commandName`).
+
+#### B4 ⛔️ Stop leaking `MimeBody` (MimeParser type) via `MimePart.body`
+
+`MimePart.body: MimeBody` (`MessageSummary+MIME.swift:205`) requires consumers to
+`import MimeParser` to use it, coupling our public API to a dependency's type.
+The decoded accessors (`decodedText`, `decodedData`) cover real use — they are all
+MailTriage touches. Make `body` internal. Also enables D-grade `Sendable` work (G2).
+
+### C. Resilience is inconsistently applied
+
+#### C1 ⛔️ Make `connect()` idempotent
+
+`ConnectionActor.swift:118` throws `invalidState("Already connected or connecting")`
+on a second `connect()`. Combined with A4, this forces MailTriage to discard and
+rebuild the entire client after any error. Recommendation: `connect()` on an
+already-connected client is a no-op; on a stale/disconnected client it reconnects.
+Documented as the contract. MailTriage can then delete its rebuild machinery
+(its choice; no forced change).
+
+#### C2 ⛔️ Apply retry/reconnect uniformly across operations
+
+Only `connect`, `listMessageUIDs`, `listMessages`, and `fetchMessage` are wrapped in
+`executeWithReconnect`. `fetchMessageBody`, `storeFlags`, `moveMessages`,
+`copyMessages`, `appendMessage`, `expunge`, and all mailbox operations call
+`connection.sendCommand` bare — so precisely the write operations (where transient
+failure hurts most) get no resilience.
+
+Nuance: writes are not idempotent. A retry after an *ambiguous* failure (command may
+have been executed) could double-APPEND or double-MOVE. Recommendation:
+
+- Reconnect-and-retry when the failure is provably pre-execution (connection was
+  already dead, command never sent).
+- For ambiguous failures, surface the error (current behaviour) — do not blind-retry
+  writes.
+- Reads (`fetchMessageBody`) get full retry like `fetchMessage`.
+
+This is behavioural, not a signature change.
+
+#### C3 ⚠️ `disconnect()` can block up to `commandTimeout` (default 60 s)
+
+`disconnect()` awaits LOGOUT, which on a dead-but-open channel waits the full command
+timeout (`ConnectionActor.swift:674` path). MailTriage works around this with
+fire-and-forget teardown. Recommendation: cap LOGOUT inside `disconnect()` at a short
+bound (e.g. 5 s), then close the channel regardless. Non-breaking.
+
+### D. Footguns
+
+#### D1 ⛔️ `expunge(uids:in:)` silently expunges the whole mailbox without UIDPLUS
+
+`IMAPClient+MessageOps.swift:189-201`: when the server lacks UIDPLUS, the targeted
+expunge falls back to a plain `EXPUNGE` — permanently deleting **every** `\Deleted`
+message in the mailbox, not just the named UIDs. Silent data loss on the worst
+possible operation. `deleteMessage`/`deleteMessages` inherit the blast radius (any
+pre-existing `\Deleted` messages from other sessions are collateral).
+Recommendation: throw `unsupportedCapability("UIDPLUS")` instead of falling back;
+document `expunge(mailbox:)` as the explicit whole-mailbox form.
+MailTriage cost: nil (does not call expunge).
+
+#### D2 ⛔️ `deleteMessages(uids:in:)` issues N round-trips then a whole-mailbox expunge
+
+`IMAPClient+MessageOps.swift:210-217` loops `markForDeletion` per UID despite a batch
+`storeFlags(uids:)` existing, then calls full `expunge(mailbox:)`. Batch the store and
+route through the UID-safe expunge (per D1).
+
+#### D3 ⛔️ `SequenceSet.set([])` returns `.single(0)`
+
+`IMAPCommand.swift:215-218`. UID 0 is invalid in IMAP; sending it is a protocol
+error. The public client methods guard with `isEmpty`, but the public static func
+itself is a trap (the comment even says "shouldn't happen"). Make it `precondition`
+or return an optional.
+
+#### D4 ⚠️ `searchMessages` fetches N+1, sequentially
+
+`IMAPClient+Search.swift:46-55` issues one `UID FETCH` per result UID, serially. A
+single `UID FETCH` with a sequence set does this in one round trip. Directly speeds
+up MailTriage's inbox load. Behaviour-compatible (same results, same order can be
+preserved).
+
+#### D5 ⚠️ `moveMessage(s)` sends a CAPABILITY command per call
+
+`capability()` issues a network round trip every time (`IMAPClient+Connection.swift:74`);
+`moveMessage(s)` calls it per move. Use the cached capabilities
+(`connection.getCapabilities()`) for the MOVE-support check.
+
+### E. Workaround knockouts (additive)
+
+#### E1 ⛔️ Parsed references: `MessageSummary.referenceIDs: [String]`
+
+`references` is the raw header value (angle brackets, folding already handled).
+MailTriage strips brackets and re-splits manually. Add a parsed accessor returning
+bare message-IDs; keep `references` for raw access. Additive.
+
+#### E2 ⛔️ UIDVALIDITY guard on write operations
+
+MailTriage manually checks `mailboxStatus().uidValidity` before every STORE/MOVE to
+avoid mutating the wrong messages after a validity change — an extra round trip and a
+TOCTOU race (validity can change between STATUS and the write). The library SELECTs
+the mailbox inside each write anyway and the SELECT response carries UIDVALIDITY, so
+it can enforce this atomically and for free.
+
+Recommendation: optional `expectedUIDValidity: UInt32?` parameter (default `nil`) on
+`storeFlags`, `moveMessages`, `copyMessages`, `expunge(uids:)`, throwing a typed
+error on mismatch. Additive, race-free, removes a STATUS round trip per write.
+
+#### E3 ⚠️ `appendMessage` should return the new UID (APPENDUID)
+
+UIDPLUS servers return `[APPENDUID uidvalidity uid]` on APPEND. Returning
+`@discardableResult ... -> UID?` (nil without UIDPLUS) is source-compatible and
+directly serves MailTriage's send-pipeline work (its #163). Recommend including in
+v2.0 since the response-code plumbing from #27 makes it cheap.
+
+### F. Surface bloat
+
+#### F1 ⛔️ Remove the convenience search wrappers
+
+`searchMessagesFrom`, `searchMessagesBySubject`, `searchMessagesByText`,
+`searchMessagesSince`, `searchUnreadMessages`, `searchFlaggedMessages`, and
+`searchMessagesComplex` (`IMAPClient+Search.swift:79-198`) are trivial one-line
+delegations to `searchMessages(criteria:)`, except `searchMessagesComplex`, which is
+a 9-parameter footprint reimplementing `.and([...])`. None are used by any known
+consumer. Seven fewer methods to document and keep compatible; README examples show
+the criteria form instead.
+
+#### F2 ⛔️ Remove deprecated `listMessages` and the sequence-number fetch path
+
+`listMessages` has carried `@available(*, deprecated)` since v1.x; a major is when it
+goes. `fetchMessageBySequence` has the same instability problem (sequence numbers
+shift under concurrent changes) and no deprecation, no retry wrapper, and no known
+consumer; remove it too. `MessageSequenceNumber` stays (it is a field of
+`MessageSummary`).
+
+#### F3 ✅ Keep: `storeFlags` overload family, mark-as helpers, mailbox management
+
+The four `storeFlags` overloads ([Flag]/[String] × single/batch) are all load-bearing
+or symmetric with load-bearing ones. `markAsRead`/`markAsUnread`/`markForDeletion`
+are used by the MOVE fallback internally and are harmless. Mailbox CRUD is standard
+IMAP and exercised by integration tests.
+
+### G. Models and conformances
+
+#### G1 ⚠️ Add `Equatable`/`Hashable` where missing
+
+`MessageSummary`, `Envelope`, `BodyStructure` lack `Equatable` (e.g. `Mailbox` and
+`MailboxStatus` have it). Additive, harmless, helps testing in consumers. Can also
+land in a minor; include in v2.0 for tidiness.
+
+#### G2 ⚠️ Make `ParsedMimeMessage` and `MimePart` `Sendable`
+
+The only model types missing `Sendable`, so they cannot cross actor boundaries in
+consumers without warnings (and will be errors under Swift 6). Blocked today by
+`MimePart.body: MimeBody` (dependency type, not Sendable) — B4 unblocks this by
+internalising `body` (storing decoded data). Do together with B4.
+
+#### G3 ⚠️ Defer: NIOSSL types in `TLSConfiguration` (v3.0)
+
+`minimumTLSVersion: TLSVersion`, `trustRoots: NIOSSLTrustRoots`,
+`certificateVerification: CertificateVerification` leak NIOSSL types into the public
+surface; customising TLS requires `import NIOSSL`. Wrapping them is real work and no
+known consumer customises TLS (MailTriage uses defaults). Park for v3.0 alongside the
+Swift 6 pass.
+
+#### G4 ✅ Fine as is
+
+- `UID = UInt32` typealias: a wrapper type would be purer but the break is not worth it.
+- `Envelope`'s paired `from`/`fromEntries` properties: clunky but functional; both
+  forms have users in principle (groups vs flattened); leave.
+- `Flag` closed enum + `keywords: Set<String>` escape hatch: right design.
+- `IMAPConfiguration` shape, defaults, and `LogLevel`: fine.
+- `RetryConfiguration` + presets: fine (presets unused but cheap and self-documenting).
+- `IMAPServerResponse`: well designed; semantic accessors are the right pattern.
+- `RFC2047.decode`: fine as a public utility.
+
+## Deliberately internal (revisit on demand)
+
+- The wire layer: `IMAPParser`, `IMAPEncoder`, `IMAPResponse` (post-B1/B2/B3),
+  `ConnectionActor`, channel handlers.
+- IDLE: `Command.idle`/`.done` exist internally but no public API drives them. A
+  future additive `idle()` AsyncSequence API is the natural v2.x feature when a
+  consumer needs push semantics. Not in v2.0 scope.
+- Capabilities cache: `capability()` (network) is public; the cached set is not.
+  Revisit if a consumer needs sync access.
+
+## Proposed v1.3 → v2.0 migration guide (summary)
+
+For the README / release notes once changes land:
+
+1. `IMAPError` is leaner and richer:
+   - removed: `mailboxNotFound`, `messageNotFound`, `quotaExceeded`,
+     `permissionDenied` (#27), `serverError`, `connectionError`, `disconnected`
+   - reshaped: `commandFailed(IMAPServerResponse)`,
+     `connectionClosed(IMAPServerResponse?)` (nil = abrupt loss),
+     `authenticationFailed(IMAPServerResponse?)`, `connectionFailed(_:underlying:)`,
+     `tlsError(_:underlying:)`, `timeout(command:)`
+   - replace case-matching on removed cases with `IMAPServerResponse` semantic
+     accessors (`isMailboxNotFound`, `isOverQuota`, `isPermissionDenied`,
+     `isAuthenticationFailure`)
+   - always include a `default` arm: new cases may be added in minor releases
+2. Wire-level types (`IMAPResponse`, `IMAPParser`, `IMAPEncoder`,
+   `IMAPCommand.Command`) are no longer public; `IMAPServerResponse.code` is now
+   `IMAPResponseCode`
+3. Removed convenience methods: use `searchMessages(in:criteria:)`
+4. `expunge(uids:)`/`deleteMessage(s)` now require UIDPLUS rather than silently
+   expunging the whole mailbox
+5. `connect()` is now idempotent; `appendMessage` returns the new UID where the
+   server supports UIDPLUS
+
+## Suggested implementation order
+
+1. A1-A5 (error surface) — one PR, extends #27, includes RetryHandler dead branches
+2. B1-B4 + G2 (internalise wire layer, MimeBody, Sendable) — one PR
+3. C1-C3 + A4 tests (connection lifecycle/resilience) — one PR, the riskiest; needs
+   GreenMail coverage
+4. D1-D5 (footguns and round-trips) — one or two PRs
+5. E1-E3 (additive workaround knockouts) — one PR
+6. F1-F2 (surface trim) — one PR, mostly deletions + README/Examples updates
+7. Migration guide + CHANGELOG consolidation + enum-policy README note — final PR

--- a/docs/error-handling-investigation.md
+++ b/docs/error-handling-investigation.md
@@ -1,0 +1,179 @@
+# Error handling investigation
+
+Investigation prompted by **MailTriage #226** ("enrich IMAPService move/copy errors with folder, UID, and server response"). MailTriage wants to attach the IMAP **server response line** (the `NO`/`BAD` status plus its text and response code) to its Bugsnag metadata. This document records what SwiftIMAP currently exposes, the gaps, and the API change required.
+
+## TL;DR
+
+- The server's response **text** is already available to consumers via `IMAPError.commandFailed(command:response:)` — but the bracketed **response code** (`[TRYCREATE]`, `[NONEXISTENT]`, `[OVERQUOTA]`, ...) and the **`NO` vs `BAD`** distinction are **silently discarded** at the point the error is built. So MailTriage cannot reconstruct a faithful server response line from the current API.
+- Four structured error cases (`mailboxNotFound`, `messageNotFound`, `quotaExceeded`, `permissionDenied`) are **declared but never produced**. Every server rejection collapses into the single generic `commandFailed`.
+- ⛔️ **Security**: the `command` field of `commandFailed` is `String(describing:)` of the command enum, which embeds the **cleartext password** for `LOGIN` and the **full message body** for `APPEND`. `errorDescription` interpolates this, so `error.localizedDescription` on a failed login leaks credentials into any log or crash report. This directly violates the "never log credentials" rule in `AGENTS.md`.
+- The API change MailTriage needs: expose the structured server response (status, response code, text, and a reconstructed line) on the thrown error, and stop embedding command arguments.
+
+## Evidence
+
+### 1. Where the error is built — the lossy site
+
+`Sources/SwiftIMAP/Networking/ConnectionActor.swift:414`
+
+```swift
+case .no(_, let message), .bad(_, let message):
+    let error = IMAPError.commandFailed(
+        command: String(describing: pending.command.command),
+        response: message ?? "Unknown error"
+    )
+    pending.continuation.resume(throwing: error)
+```
+
+Three losses happen here:
+
+- **Response code dropped.** `.no(_, ...)` / `.bad(_, ...)` discard the `ResponseCode?` first tuple element. The parser has already extracted it (see below), so `[TRYCREATE]`, `[NONEXISTENT]`, `[OVERQUOTA]`, `[ALERT]`, `[INUSE]`, etc. are thrown away. That code is the single most machine-actionable field for distinguishing the mutually-exclusive causes the MailTriage issue calls out (folder missing vs quota vs server-side rule).
+- **`NO` vs `BAD` collapsed.** Both map to one `commandFailed` case. `NO` = operational failure (retry/repair candidate); `BAD` = protocol/syntax error (a client bug, never retry). Consumers cannot tell them apart.
+- **Code stripped from the text too.** The parser separates the bracket code from the trailing text, so even `response` does **not** contain `[NONEXISTENT]` — only the human prose after it.
+
+### 2. The parser already has the structured data
+
+`Sources/SwiftIMAP/Protocol/IMAPParser+Responses.swift:137` (`parseResponseCodeAndText`) splits `[CODE] text` into `(ResponseCode?, String?)`, and `parseResponseCode` (`:159`) maps known codes to typed cases, falling back to `.other(name, value)` for unknown ones (`:210`). So the information MailTriage wants is parsed and then deliberately dropped one layer up. No new parsing is required — only plumbing it through the error.
+
+`IMAPResponse.ResponseStatus` and `ResponseCode` are already `public` (`Sources/SwiftIMAP/Protocol/IMAPResponse.swift:8` and `:30`), so they can be surfaced on the error without new public types.
+
+### 3. Dead error cases
+
+Counting producers in `Sources/` (excluding the enum declaration itself):
+
+| Case | Producers | Notes |
+|------|-----------|-------|
+| `commandFailed` | 1 | the only path for every server `NO`/`BAD` |
+| `mailboxNotFound` | 0 | declared, never thrown |
+| `messageNotFound` | 0 | declared, never thrown |
+| `quotaExceeded` | 0 | declared, never thrown |
+| `permissionDenied` | 0 | declared, never thrown |
+
+A `MOVE` to a non-existent folder returns `commandFailed`, not `mailboxNotFound`; an over-quota `APPEND`/`COPY` returns `commandFailed`, not `quotaExceeded`. The structured cases are aspirational. They could be populated by mapping response codes (`[NONEXISTENT]`/`[TRYCREATE]` → `mailboxNotFound`, `[OVERQUOTA]` → `quotaExceeded`, `[NOPERM]` → `permissionDenied`) — but only once the code is actually carried through (gap 1).
+
+### 4. ⛔️ Credential / payload leak via `String(describing:)`
+
+`Sources/SwiftIMAP/Protocol/IMAPCommand.swift:18` — `case login(username: String, password: String)`.
+
+The login path reaches the lossy site: `IMAPClient+Connection.swift:99` calls `connection.sendCommand(.login(...))`, and a rejected login returns a tagged `NO`, so `ConnectionActor.swift:415` builds:
+
+```swift
+command: String(describing: .login(username: "user@x", password: "hunter2"))
+// => "login(username: \"user@x\", password: \"hunter2\")"
+```
+
+`IMAPError.errorDescription` (`Errors/IMAPError.swift:39`) then interpolates that into:
+
+```
+Command 'login(username: "user@x", password: "hunter2")' failed: ...
+```
+
+So `error.localizedDescription` on a failed login contains the plaintext password. Same mechanism leaks:
+
+- the base64 SASL initial response (PLAIN credentials / OAuth2 access token) for `.authenticate(mechanism:initialResponse:)` (`IMAPCommand.swift:17`);
+- the **entire message body** for `.append(... data: Data)` (`IMAPCommand.swift:29`).
+
+If MailTriage forwards `IMAPError` text to Bugsnag (the obvious thing for issue #226 to do), it would publish credentials and message content. This must be fixed as part of the same change, not after.
+
+### 5. Retry classification can't see server intent
+
+`Sources/SwiftIMAP/Utilities/RetryHandler.swift:127` only treats `.serverError` (matched on substrings like `UNAVAILABLE`, `TRY AGAIN`) as a temporary failure. But server rejections arrive as `.commandFailed`, which hits `default: return false` (`:132`) — non-retryable. A transient `NO [INUSE]`/`NO [UNAVAILABLE]` is therefore never retried even when retry would help, and there is no typed signal (status/code) for the retry handler to make that decision correctly. Carrying the structured response would let `isRetryableError` branch on `[INUSE]`/`[UNAVAILABLE]`/`[SERVERBUG]` instead of substring-sniffing free text.
+
+## Other error sites worth fixing in the same pass
+
+Sweeping every `IMAPError` producer (not just the move/copy path) surfaces the same two themes — **context discarded at construction** and **typed information flattened to strings** — in several more places. Folding them into one change avoids churning the public error surface twice.
+
+### 6. `connect()` retries are a no-op for real connection failures
+
+`ConnectionActor.connect()` wraps every failure as `IMAPError.connectionFailed(error.localizedDescription)` (`ConnectionActor.swift:173`). But `RetryHandler.isRetryableError` only retries `.connectionError`/`.connectionClosed` (`RetryHandler.swift:123`) — `.connectionFailed` is absent, so it falls to `default: return false`. Since `IMAPClient.connect()` runs inside `retryHandler.execute(operation: "connect")` (`IMAPClient+Connection.swift:24`), a refused/DNS/transient connection failure is **never retried** — the retry wrapper around connect does nothing. `connectionFailed` and `connectionError` are near-duplicate cases with diverging retry behaviour; they should be unified, or `connectionFailed` added to the retryable set.
+
+### 7. Underlying errors flattened to strings (`connectionFailed`, `tlsError`)
+
+- `ConnectionActor.swift:173` — `connectionFailed(error.localizedDescription)` discards the typed underlying error (NIO `NIOConnectionError`, POSIX errno, DNS failure). On Apple platforms these often stringify to unhelpful generic text, losing exactly the connection-state detail #226 wants for diagnosis.
+- `ConnectionActor.swift:197` — `tlsError(error.localizedDescription)` likewise drops the `NIOSSLError` / certificate-chain detail.
+
+Both should retain `underlying: Error` (as an associated value) so consumers can inspect or report the real cause. AGENTS.md already promises "network errors include connection state information" — today they don't.
+
+### 8. `timeout` carries no context
+
+`handleTimeout` (`ConnectionActor.swift:610`) has the `tag` and the full `pending.command` in scope but throws a bare `IMAPError.timeout` (`:616`). The greeting path (`:457`) does the same. A timeout on `UID MOVE` and a timeout on the initial greeting are indistinguishable to the caller — directly the kind of "we can't tell what failed" gap this investigation is about. Attach the command label (the same argument-free label introduced for the security fix) and ideally the elapsed seconds. Note also the greeting timeout is hardcoded to 5s (`:458`) and ignores `configuration.connectionTimeout` — worth correcting while in here.
+
+### 9. `BYE` greeting text discarded — same loss as `NO`/`BAD`
+
+`IMAPClient+Connection.swift:33` maps a `* BYE` greeting to a bare `IMAPError.connectionClosed`, discarding the `ResponseCode?` and text. Servers reject connections with actionable detail here — `BYE [ALERT] Too many connections`, `BYE [UNAVAILABLE] ...`, account-disabled messages. This is the same structured-response loss as the `NO`/`BAD` path and should reuse the same `IMAPServerResponse` treatment (extend `Status` with a `bye` case, or surface it on a `connectionClosed(IMAPServerResponse?)`).
+
+### 10. Parser errors may embed raw message bytes (privacy)
+
+The 50+ `parsingError(String)` sites deliberately include the offending input (AGENTS.md: "parser errors include the problematic input line"). For `FETCH` body/envelope/body-structure failures that "input" is **message content** — subject lines, body fragments. If MailTriage logs `parsingError` text to Bugsnag, email content leaks. Lower severity than the credential leak (gap 4) but the same privacy family. Recommend truncating embedded input and/or tagging these errors so the consumer can choose not to forward the payload.
+
+## The API change MailTriage needs
+
+MailTriage's `IMAPOperationError` wants `serverResponseLine: String?`. To supply it faithfully, SwiftIMAP must surface the structured rejection. Proposed shape:
+
+```swift
+public struct IMAPServerResponse: Sendable, Equatable {
+    public enum Status: String, Sendable { case no = "NO", bad = "BAD" }
+
+    public let status: Status                       // NO vs BAD
+    public let code: IMAPResponse.ResponseCode?     // [TRYCREATE], [OVERQUOTA], .other(...)
+    public let text: String?                        // human text after the code
+    public let commandName: String                  // sanitised, e.g. "UID MOVE" — NEVER arguments
+
+    /// Reconstructed server line for logging: `NO [TRYCREATE] Mailbox does not exist`
+    public var line: String {
+        var parts = [status.rawValue]
+        if let code { parts.append("[\(Self.render(code))]") }
+        if let text { parts.append(text) }
+        return parts.joined(separator: " ")
+    }
+}
+```
+
+Then carry it on the error. Cleanest is to redesign the single producing case rather than add a parallel one:
+
+```swift
+case commandFailed(IMAPServerResponse)
+```
+
+and at `ConnectionActor.swift:414`:
+
+```swift
+case .no(let code, let text), .bad(let code, let text):
+    let response = IMAPServerResponse(
+        status: isNo ? .no : .bad,
+        code: code,
+        text: text,
+        commandName: pending.command.command.label   // new: argument-free label
+    )
+    pending.continuation.resume(throwing: IMAPError.commandFailed(response))
+```
+
+Add an argument-free `label` (or `commandName`) to `IMAPCommand.Command` (`"LOGIN"`, `"UID MOVE"`, `"APPEND"`, ...) and use it everywhere instead of `String(describing:)`. This both gives MailTriage a clean operation string and closes the credential/payload leak.
+
+### Compatibility note
+
+`commandFailed(command:response:)` is part of the public API at v1.2.4, so changing its shape is source-breaking. Options, in order of preference:
+
+1. **Redesign `commandFailed` to carry `IMAPServerResponse`** and ship as **v2.0** (or v1.3 with a deprecation shim). Cleanest long-term; MailTriage is the only known consumer and the team controls it.
+2. **Keep `commandFailed(command:response:)`, add `commandRejected(IMAPServerResponse)`** as a new case and switch the producer to it. Additive (minor bump) but leaves a dead legacy case and two ways to express the same thing.
+
+Recommendation: option 1, bundled with the credential-leak fix, as a single v2.0. The leak fix is a security change that justifies the breaking bump on its own, and doing both at once avoids two churns of the public error surface.
+
+### Acceptance-criteria mapping (issue #226)
+
+- folder path, message UID, account provider id — these live in **MailTriage**'s wrapper; SwiftIMAP doesn't have them and shouldn't. No SwiftIMAP change needed.
+- **server response line** — needs the change above (`IMAPServerResponse.line`).
+- "verified via a deliberate failure (move to non-existent folder against GreenMail)" — add a SwiftIMAP integration test asserting the thrown `commandFailed` carries `status == .no` and a `[TRYCREATE]`/`[NONEXISTENT]` code, so the contract MailTriage relies on is locked in.
+
+## Combined change for v2.0
+
+These all touch the public error surface, so doing them together as one breaking release (rather than fragmenting) is the right call. Ordered by dependency:
+
+1. **Sanitised command label** — add an argument-free `label`/`commandName` to `IMAPCommand.Command` (`"LOGIN"`, `"UID MOVE"`, `"APPEND"`, ...). This is the foundation for the rest and closes the credential/payload leak (gaps 4, 8). Add a test that a failed `LOGIN` error contains neither username nor password.
+2. **`IMAPServerResponse`** — new struct carrying status (`NO`/`BAD`/`BYE`), `ResponseCode?`, text, and the sanitised command label, with a computed `.line` for logging. Carry it on `commandFailed` and fold the `BYE` greeting into it (gaps 1, 2, 9). Add a GreenMail test for a rejected `MOVE` asserting `status == .no` and a `[TRYCREATE]`/`[NONEXISTENT]` code — this locks the contract MailTriage depends on.
+3. **Preserve underlying errors** — give `connectionFailed` and `tlsError` an `underlying: Error` associated value instead of `error.localizedDescription` (gap 7).
+4. **Context on `timeout`** — attach the command label and elapsed seconds; fix the greeting timeout to honour `configuration.connectionTimeout` (gap 8).
+5. **Retry consistency** — unify `connectionFailed`/`connectionError` (or add `connectionFailed` to the retryable set) so `connect()` actually retries (gap 6); branch `isRetryableError` on the typed status/code (`[INUSE]`, `[UNAVAILABLE]`) instead of substring-matching free text (gap 5).
+6. **Dead cases** — either populate `mailboxNotFound`/`messageNotFound`/`quotaExceeded`/`permissionDenied` by mapping response codes (`[NONEXISTENT]`/`[TRYCREATE]`, `[OVERQUOTA]`, `[NOPERM]`), or remove them as dead API (gap 3).
+7. **Parser-input privacy** — truncate or tag the raw input embedded in `parsingError` so consumers can avoid forwarding message content to crash reporters (gap 10).
+
+Items 1–2 directly satisfy MailTriage #226's server-response-line requirement; 3–7 are the rest of the library's error surface caught in the same sweep. The credential-leak fix (item 1) is reason enough for the major bump on its own.


### PR DESCRIPTION
## Summary
- Full review of the public API surface (~47 types / ~232 members) against measured MailTriage usage, ahead of the v2.0 release
- Findings classified and resolved into a v2.0 scope after independent review; decisions recorded in the doc (`docs/api-review-v2.md`)
- Resulting work items: #35 #36 #37 #38 #39 on the v2.0 milestone
- Also removes the blanket `docs/*` gitignore (meant for generated DocC output, which lives in `.docc-build/`) and tracks the previously ignored #27 error-handling investigation doc

## Testing
Doc-only change, no code paths affected. `swift build` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)