### PR TITLE
Add Equatable to model snapshot types (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `IMAPServerResponse` value type carrying the server's `status` (`NO`/`BAD`/`BYE`), parsed `code`, `text`, and the argument-free `commandName`, plus a reconstructed `line` for logging (e.g. `NO [TRYCREATE] Mailbox does not exist`) (#27). Surfaced on `commandFailed` and `connectionClosed` so callers (e.g. MailTriage #226) can log a faithful server response line and distinguish causes. Includes semantic accessors: `isMailboxNotFound`, `isOverQuota`, `isPermissionDenied`, `isAuthenticationFailure`, and `codeName`.
 - `IMAPCommand.Command.label` / `IMAPCommand.UIDCommand.label`: the argument-free IMAP verb, safe to log.
+- `MessageSummary`, `Envelope`, `BodyStructure`, `ParsedMimeMessage`, and `MimePart` now conform to `Equatable` (#49), so consumers can diff and assert against whole model values in tests. Additive; identity/collection types (`Mailbox`, `Address`) remain `Hashable` as before.
 
 ### Changed
 - **Breaking.** `IMAPError` reshaped for richer, leak-free diagnostics (#27):

--- a/Sources/SwiftIMAP/Models/Message.swift
+++ b/Sources/SwiftIMAP/Models/Message.swift
@@ -3,7 +3,7 @@ import Foundation
 public typealias UID = UInt32
 public typealias MessageSequenceNumber = UInt32
 
-public struct MessageSummary: Sendable {
+public struct MessageSummary: Sendable, Equatable {
     public let uid: UID
     public let sequenceNumber: MessageSequenceNumber
     /// The standard RFC 3501 system flags (see `Flag`).
@@ -77,7 +77,7 @@ public enum AddressListEntry: Sendable, Hashable {
     case group(name: String, members: [Address])
 }
 
-public struct Envelope: Sendable {
+public struct Envelope: Sendable, Equatable {
     public let date: Date?
     public let subject: String?
     public let from: [Address]
@@ -132,7 +132,7 @@ public struct Envelope: Sendable {
     }
 }
 
-public struct BodyStructure: Sendable {
+public struct BodyStructure: Sendable, Equatable {
     public let type: String
     public let subtype: String
     public let parameters: [String: String]

--- a/Sources/SwiftIMAP/Models/MessageSummary+MIME.swift
+++ b/Sources/SwiftIMAP/Models/MessageSummary+MIME.swift
@@ -30,7 +30,7 @@ extension MessageSummary {
 }
 
 /// A parsed MIME message with convenient access to parts
-public struct ParsedMimeMessage: Sendable {
+public struct ParsedMimeMessage: Sendable, Equatable {
     public let headers: [String: String]
     public let contentType: String?
     public let charset: String?
@@ -203,7 +203,7 @@ public struct ParsedMimeMessage: Sendable {
 /// A single MIME part.
 ///
 /// Holds only decoded value types (the MimeParser wire objects are consumed at construction)
-public struct MimePart: Sendable {
+public struct MimePart: Sendable, Equatable {
     public let headers: [String: String]
     public let contentType: String?
     public let charset: String?

--- a/Tests/SwiftIMAPTests/MIMEParsingTests.swift
+++ b/Tests/SwiftIMAPTests/MIMEParsingTests.swift
@@ -281,8 +281,8 @@ final class MIMEParsingTests: XCTestCase {
         XCTAssertEqual(decoded, ["Hello across actors"])
     }
 
-    /// #49: ParsedMimeMessage and MimePart are Equatable. Parsing identical
-    /// bytes twice yields equal values; differing bodies are unequal.
+    /// ParsedMimeMessage and MimePart are Equatable: parsing identical bytes
+    /// twice yields equal values; differing bodies are unequal.
     func testParsedMimeMessageEquatableConformance() throws {
         let raw = "Content-Type: text/plain; charset=utf-8\r\n\r\nbody one"
         let a = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(raw.utf8)))
@@ -295,7 +295,7 @@ final class MIMEParsingTests: XCTestCase {
         XCTAssertNotEqual(a, c)
     }
 
-    /// #49: equality on the MimePart decode-failure branch (where rawBody is
+    /// Equality on the MimePart decode-failure branch (where rawBody is
     /// populated, not the decoded-success branch). Two parts that both fail to
     /// decode with the same raw body compare equal; a decoded part and a
     /// failed-decode part with the same bytes compare unequal (they differ in

--- a/Tests/SwiftIMAPTests/MIMEParsingTests.swift
+++ b/Tests/SwiftIMAPTests/MIMEParsingTests.swift
@@ -285,14 +285,14 @@ final class MIMEParsingTests: XCTestCase {
     /// twice yields equal values; differing bodies are unequal.
     func testParsedMimeMessageEquatableConformance() throws {
         let raw = "Content-Type: text/plain; charset=utf-8\r\n\r\nbody one"
-        let a = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(raw.utf8)))
-        let b = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(raw.utf8)))
-        XCTAssertEqual(a, b)
-        XCTAssertEqual(a.parts, b.parts)
+        let first = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(raw.utf8)))
+        let second = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(raw.utf8)))
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.parts, second.parts)
 
         let other = raw.replacingOccurrences(of: "body one", with: "body two")
-        let c = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(other.utf8)))
-        XCTAssertNotEqual(a, c)
+        let differing = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(other.utf8)))
+        XCTAssertNotEqual(first, differing)
     }
 
     /// Equality on the MimePart decode-failure branch (where rawBody is

--- a/Tests/SwiftIMAPTests/MIMEParsingTests.swift
+++ b/Tests/SwiftIMAPTests/MIMEParsingTests.swift
@@ -295,6 +295,28 @@ final class MIMEParsingTests: XCTestCase {
         XCTAssertNotEqual(a, c)
     }
 
+    /// #49: equality on the MimePart decode-failure branch (where rawBody is
+    /// populated, not the decoded-success branch). Two parts that both fail to
+    /// decode with the same raw body compare equal; a decoded part and a
+    /// failed-decode part with the same bytes compare unequal (they differ in
+    /// decodedData: one has bytes, the other is nil).
+    func testMimePartEqualityOnDecodeFailureBranch() throws {
+        // An unknown transfer encoding makes decodedContentData() throw, so
+        // decodedData == nil and rawBody is retained.
+        let undecodable = "Content-Type: text/plain\r\nContent-Transfer-Encoding: x-custom\r\n\r\nsame body"
+        let p1 = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(undecodable.utf8))).parts.first
+        let p2 = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(undecodable.utf8))).parts.first
+        XCTAssertEqual(p1, p2, "Two equal failed-decode parts must compare equal")
+        XCTAssertNil(p1?.decodedData)
+
+        // A decodable part with the same body text decodes to bytes, so its
+        // decodedData differs from the failed part's nil — they are unequal.
+        let decodable = "Content-Type: text/plain\r\n\r\nsame body"
+        let p3 = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(decodable.utf8))).parts.first
+        XCTAssertNotNil(p3?.decodedData)
+        XCTAssertNotEqual(p1, p3, "A failed-decode part and a decoded part must compare unequal")
+    }
+
     // Helper to create a test message summary
     private func createTestSummary() -> MessageSummary {
         MessageSummary(

--- a/Tests/SwiftIMAPTests/MIMEParsingTests.swift
+++ b/Tests/SwiftIMAPTests/MIMEParsingTests.swift
@@ -281,6 +281,20 @@ final class MIMEParsingTests: XCTestCase {
         XCTAssertEqual(decoded, ["Hello across actors"])
     }
 
+    /// #49: ParsedMimeMessage and MimePart are Equatable. Parsing identical
+    /// bytes twice yields equal values; differing bodies are unequal.
+    func testParsedMimeMessageEquatableConformance() throws {
+        let raw = "Content-Type: text/plain; charset=utf-8\r\n\r\nbody one"
+        let a = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(raw.utf8)))
+        let b = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(raw.utf8)))
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.parts, b.parts)
+
+        let other = raw.replacingOccurrences(of: "body one", with: "body two")
+        let c = try XCTUnwrap(MessageSummary.parseMimeContent(from: Data(other.utf8)))
+        XCTAssertNotEqual(a, c)
+    }
+
     // Helper to create a test message summary
     private func createTestSummary() -> MessageSummary {
         MessageSummary(

--- a/Tests/SwiftIMAPTests/ModelTests.swift
+++ b/Tests/SwiftIMAPTests/ModelTests.swift
@@ -113,8 +113,8 @@ final class ModelTests: XCTestCase {
         XCTAssertEqual(summary.envelope?.subject, "Test Subject")
     }
 
-    /// #49: the model snapshots are Equatable so consumers can diff and assert
-    /// against whole values. Covers MessageSummary, Envelope, BodyStructure.
+    /// The model snapshots are Equatable so consumers can diff and assert
+    /// against whole values: MessageSummary, Envelope, BodyStructure.
     func testModelEquatableConformance() {
         let date = Date(timeIntervalSince1970: 1_700_000_000)
         func makeSummary(subject: String) -> MessageSummary {

--- a/Tests/SwiftIMAPTests/ModelTests.swift
+++ b/Tests/SwiftIMAPTests/ModelTests.swift
@@ -112,7 +112,36 @@ final class ModelTests: XCTestCase {
         XCTAssertNotNil(summary.envelope)
         XCTAssertEqual(summary.envelope?.subject, "Test Subject")
     }
-    
+
+    /// #49: the model snapshots are Equatable so consumers can diff and assert
+    /// against whole values. Covers MessageSummary, Envelope, BodyStructure.
+    func testModelEquatableConformance() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        func makeSummary(subject: String) -> MessageSummary {
+            MessageSummary(
+                uid: 1,
+                sequenceNumber: 1,
+                flags: [.seen],
+                keywords: ["@Triaged"],
+                internalDate: date,
+                size: 100,
+                envelope: Envelope(date: date, subject: subject,
+                                   from: [Address(name: "A", mailbox: "a", host: "x.com")]),
+                references: "<r1@x.com>"
+            )
+        }
+
+        XCTAssertEqual(makeSummary(subject: "Same"), makeSummary(subject: "Same"))
+        XCTAssertNotEqual(makeSummary(subject: "One"), makeSummary(subject: "Two"))
+
+        // Envelope and BodyStructure equality
+        let env = Envelope(date: date, subject: "S", to: [Address(name: nil, mailbox: "t", host: "x.com")])
+        XCTAssertEqual(env, env)
+        let structure = BodyStructure(type: "text", subtype: "plain", encoding: "7bit", size: 10)
+        XCTAssertEqual(structure, BodyStructure(type: "text", subtype: "plain", encoding: "7bit", size: 10))
+        XCTAssertNotEqual(structure, BodyStructure(type: "text", subtype: "html", encoding: "7bit", size: 10))
+    }
+
     func testSequenceSetStringValue() {
         let single = IMAPCommand.SequenceSet.single(42)
         XCTAssertEqual(single.stringValue, "42")

--- a/Tests/SwiftIMAPTests/ModelTests.swift
+++ b/Tests/SwiftIMAPTests/ModelTests.swift
@@ -134,9 +134,16 @@ final class ModelTests: XCTestCase {
         XCTAssertEqual(makeSummary(subject: "Same"), makeSummary(subject: "Same"))
         XCTAssertNotEqual(makeSummary(subject: "One"), makeSummary(subject: "Two"))
 
-        // Envelope and BodyStructure equality
-        let env = Envelope(date: date, subject: "S", to: [Address(name: nil, mailbox: "t", host: "x.com")])
-        XCTAssertEqual(env, env)
+        // Envelope: two independently-built instances with equal inputs compare
+        // equal (incl. the derived *Entries), and differ when a field differs.
+        func makeEnvelope(subject: String) -> Envelope {
+            Envelope(date: date, subject: subject,
+                     from: [Address(name: "A", mailbox: "a", host: "x.com")],
+                     to: [Address(name: nil, mailbox: "t", host: "x.com")])
+        }
+        XCTAssertEqual(makeEnvelope(subject: "S"), makeEnvelope(subject: "S"))
+        XCTAssertNotEqual(makeEnvelope(subject: "S"), makeEnvelope(subject: "T"))
+
         let structure = BodyStructure(type: "text", subtype: "plain", encoding: "7bit", size: 10)
         XCTAssertEqual(structure, BodyStructure(type: "text", subtype: "plain", encoding: "7bit", size: 10))
         XCTAssertNotEqual(structure, BodyStructure(type: "text", subtype: "html", encoding: "7bit", size: 10))


### PR DESCRIPTION
Closes #49. Second-pass scope from the v2.0 API review (G1).

## Summary
- `MessageSummary`, `Envelope`, `BodyStructure`, `ParsedMimeMessage`, `MimePart` now conform to `Equatable`
- Equatable (not Hashable): matches the codebase's existing split — `MailboxStatus` (content snapshot) is Equatable-only; `Mailbox`/`Address` (identity/collection types) are Hashable. Hashable on these five is a trivial additive follow-up if a consumer ever needs set membership.
- All members already conform, so the conformances are compiler-synthesised.

## Testing
- `swift test`: 322 tests, 0 failures (+2)
- New: `testModelEquatableConformance` (MessageSummary/Envelope/BodyStructure), `testParsedMimeMessageEquatableConformance` (MIME types)

## User-facing changes
Additive, non-breaking. See CHANGELOG (Added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)