### PR TITLE
Docs: tighten README log-safety wording, mark internal docs historical

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,10 @@ let labeled = try await client.searchMessages(in: "INBOX", criteria: .keyword("P
 
 All operations throw `IMAPError`. When the server rejects a command, `commandFailed`
 carries a structured `IMAPServerResponse` so you can log a faithful server response
-line and distinguish causes. None of the error output includes credentials or message
-data.
+line and distinguish causes. SwiftIMAP never puts command arguments, credentials, or
+message bodies into error output. Note that `IMAPServerResponse.line` includes the
+server's own response text, which some servers echo user-specific details into (e.g. a
+mailbox name); treat it as potentially sensitive before exporting to third parties.
 
 ```swift
 do {

--- a/README.md
+++ b/README.md
@@ -219,10 +219,13 @@ let labeled = try await client.searchMessages(in: "INBOX", criteria: .keyword("P
 
 All operations throw `IMAPError`. When the server rejects a command, `commandFailed`
 carries a structured `IMAPServerResponse` so you can log a faithful server response
-line and distinguish causes. SwiftIMAP never puts command arguments, credentials, or
-message bodies into error output. Note that `IMAPServerResponse.line` includes the
-server's own response text, which some servers echo user-specific details into (e.g. a
-mailbox name); treat it as potentially sensitive before exporting to third parties.
+line and distinguish causes. SwiftIMAP never puts your command arguments, credentials,
+or message bodies into error output. Two caveats on server-supplied text: a
+`commandFailed`/`connectionClosed` response `line` includes the server's own text,
+which some servers echo user-specific details into (e.g. a mailbox name); and a
+`parsingError` embeds a truncated slice of the offending server input for diagnostics,
+which can include message content. Treat both as potentially sensitive before exporting
+to third parties.
 
 ```swift
 do {
@@ -232,7 +235,8 @@ do {
     case .commandFailed(let response):
         // response.status  -> .no / .bad
         // response.code    -> e.g. .tryCreate, .other("OVERQUOTA", nil)
-        // response.line    -> "NO [TRYCREATE] Mailbox does not exist" (safe to log)
+        // response.line    -> "NO [TRYCREATE] Mailbox does not exist"
+        //                     (server text — may echo user details like a mailbox name)
         log.error("\(response.commandName) failed: \(response.line)")
         if response.isMailboxNotFound { /* destination renamed or removed */ }
         if response.isOverQuota { /* account over quota */ }

--- a/docs/api-review-v2.md
+++ b/docs/api-review-v2.md
@@ -1,5 +1,10 @@
 # SwiftIMAP v2.0 external API review
 
+> **Historical / internal record.** A point-in-time review snapshot from v2.0
+> development, kept for the audit trail. It uses the names and findings as they
+> were at review time and is **not** current API guidance — see `README.md` and
+> `docs/migration-v1-to-v2.md` for that. (Scheduled for removal at the v2.0 tag.)
+
 Date: 2026-06-06. Branch under review: `version/v2.0` (post-#27 error-handling work).
 
 ## Brief

--- a/docs/error-handling-investigation.md
+++ b/docs/error-handling-investigation.md
@@ -1,5 +1,11 @@
 # Error handling investigation
 
+> **Historical / internal record.** A point-in-time investigation from v2.0
+> development, kept for the audit trail. It describes the pre-fix state and uses
+> the names as they were then; it is **not** current API guidance — see
+> `README.md` and `docs/migration-v1-to-v2.md`. (Scheduled for removal at the
+> v2.0 tag.)
+
 Investigation prompted by **MailTriage #226** ("enrich IMAPService move/copy errors with folder, UID, and server response"). MailTriage wants to attach the IMAP **server response line** (the `NO`/`BAD` status plus its text and response code) to its Bugsnag metadata. This document records what SwiftIMAP currently exposes, the gaps, and the API change required.
 
 ## TL;DR


### PR DESCRIPTION
Two doc-only fixes from the external review (findings #7 and #8). Doc-only — no code, no CHANGELOG — independent of the other branches.

- **#7**: the README error-handling note claimed "none of the error output includes credentials or message data" as an absolute. SwiftIMAP never emits command arguments/credentials/message bodies, but `IMAPServerResponse.line` includes the server's own text, which some servers echo user-specific details into. Reworded precisely (and points out the `.line` caveat, which `IMAPServerResponse` already documents).
- **#8**: added a "historical / internal" banner to `docs/api-review-v2.md` and `docs/error-handling-investigation.md` so adopters don't mistake these point-in-time records for current guidance. They remain scheduled for removal at the v2.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)